### PR TITLE
Make trial keywords display optional

### DIFF
--- a/app/controllers/admin/system_controller.rb
+++ b/app/controllers/admin/system_controller.rb
@@ -41,7 +41,8 @@ class Admin::SystemController < ApplicationController
         :google_analytics_id,
         :display_all_locations,
         :researcher_description,
-        :secret_key
+        :secret_key,
+        :display_keywords
       )
     end
 end

--- a/app/views/admin/system/edit.html.haml
+++ b/app/views/admin/system/edit.html.haml
@@ -53,6 +53,11 @@
       %i (When a trial is located at multiple sites "display locations" determines if those other sites be listed within StudyFinder)
     = f.input :display_all_locations, as: :select, label: false
 
+    %label Display Keywords
+    %small
+      %i (Show a trial's keywords in the search results)
+    = f.input :display_keywords, as: :select, label: false
+
     = f.input :researcher_description, as: :text, input_html: { rows: 5 }
 
     %hr

--- a/app/views/studies/index.html.haml
+++ b/app/views/studies/index.html.haml
@@ -156,7 +156,7 @@
           .concept-list
             = highlight(t, 'conditions_map').gsub(';', ',').html_safe
 
-      - unless t.keywords.nil?
+      - if @system_info.display_keywords? && !t.keywords.blank?
         .field.nomargin
           %label.single Keywords:
           .concept-list

--- a/db/migrate/20191217194422_add_display_keywords_to_system_infos.rb
+++ b/db/migrate/20191217194422_add_display_keywords_to_system_infos.rb
@@ -1,0 +1,5 @@
+class AddDisplayKeywordsToSystemInfos < ActiveRecord::Migration[5.2]
+  def change
+    add_column :study_finder_system_infos, :display_keywords, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,226 +10,225 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180126133905) do
+ActiveRecord::Schema.define(version: 2019_12_17_194422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "study_finder_condition_groups", force: :cascade do |t|
-    t.integer  "group_id"
-    t.integer  "condition_id"
+  create_table "study_finder_condition_groups", id: :serial, force: :cascade do |t|
+    t.integer "group_id"
+    t.integer "condition_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_finder_conditions", force: :cascade do |t|
-    t.string   "condition",  limit: 1000
+  create_table "study_finder_conditions", id: :serial, force: :cascade do |t|
+    t.string "condition", limit: 1000
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_finder_disease_sites", force: :cascade do |t|
-    t.string   "disease_site_name"
-    t.integer  "group_id"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+  create_table "study_finder_disease_sites", id: :serial, force: :cascade do |t|
+    t.string "disease_site_name"
+    t.integer "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "study_finder_ds_trials", force: :cascade do |t|
+  create_table "study_finder_ds_trials", id: :serial, force: :cascade do |t|
     t.integer "disease_site_id"
     t.integer "trial_id"
   end
 
-  create_table "study_finder_groups", force: :cascade do |t|
-    t.string   "group_name"
+  create_table "study_finder_groups", id: :serial, force: :cascade do |t|
+    t.string "group_name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "children"
-    t.boolean  "adults"
-    t.boolean  "healthy_volunteers"
+    t.boolean "children"
+    t.boolean "adults"
+    t.boolean "healthy_volunteers"
   end
 
-  create_table "study_finder_locations", force: :cascade do |t|
-    t.string   "location",   limit: 1000
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip"
-    t.string   "country"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "study_finder_parsers", force: :cascade do |t|
-    t.string   "name"
-    t.string   "klass"
+  create_table "study_finder_locations", id: :serial, force: :cascade do |t|
+    t.string "location", limit: 1000
+    t.string "city"
+    t.string "state"
+    t.string "zip"
+    t.string "country"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_finder_sites", force: :cascade do |t|
-    t.string   "site_name"
-    t.string   "address"
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip"
+  create_table "study_finder_parsers", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "klass"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "study_finder_sites", id: :serial, force: :cascade do |t|
+    t.string "site_name"
+    t.string "address"
+    t.string "city"
+    t.string "state"
+    t.string "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "study_finder_subgroups", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "group_id"
+  create_table "study_finder_subgroups", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.integer "group_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_finder_system_infos", force: :cascade do |t|
-    t.string   "initials"
-    t.string   "school_name"
-    t.string   "system_name"
-    t.string   "system_header"
-    t.string   "system_description",      limit: 2000
-    t.string   "search_term"
-    t.string   "default_url"
-    t.string   "default_email"
-    t.string   "research_match_campaign"
+  create_table "study_finder_system_infos", id: :serial, force: :cascade do |t|
+    t.string "initials"
+    t.string "school_name"
+    t.string "system_name"
+    t.string "system_header"
+    t.string "system_description", limit: 2000
+    t.string "search_term"
+    t.string "default_url"
+    t.string "default_email"
+    t.string "research_match_campaign"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "secret_key"
-    t.string   "google_analytics_id"
-    t.boolean  "display_all_locations"
-    t.string   "contact_email_suffix"
-    t.text     "researcher_description"
-    t.boolean  "captcha",                              default: false, null: false
+    t.string "secret_key"
+    t.string "google_analytics_id"
+    t.boolean "display_all_locations"
+    t.string "contact_email_suffix"
+    t.text "researcher_description"
+    t.boolean "captcha", default: false, null: false
+    t.boolean "display_keywords", default: true
   end
 
-  create_table "study_finder_trial_conditions", force: :cascade do |t|
-    t.integer  "trial_id"
-    t.integer  "condition_id"
+  create_table "study_finder_trial_conditions", id: :serial, force: :cascade do |t|
+    t.integer "trial_id"
+    t.integer "condition_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["condition_id"], name: "condition_idx"
   end
 
-  add_index "study_finder_trial_conditions", ["condition_id"], name: "condition_idx", using: :btree
-
-  create_table "study_finder_trial_intervents", force: :cascade do |t|
-    t.integer  "trial_id"
-    t.string   "intervention_type"
-    t.string   "intervention"
-    t.string   "description",       limit: 4000
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "study_finder_trial_keywords", force: :cascade do |t|
-    t.integer  "trial_id"
-    t.string   "keyword"
+  create_table "study_finder_trial_intervents", id: :serial, force: :cascade do |t|
+    t.integer "trial_id"
+    t.string "intervention_type"
+    t.string "intervention"
+    t.string "description", limit: 4000
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_finder_trial_locations", force: :cascade do |t|
-    t.integer  "trial_id"
-    t.integer  "location_id"
-    t.string   "status"
-    t.string   "last_name"
-    t.string   "phone"
-    t.string   "email"
-    t.string   "backup_last_name"
-    t.string   "backup_phone"
-    t.string   "backup_email"
-    t.string   "investigator_last_name"
-    t.string   "investigator_role"
+  create_table "study_finder_trial_keywords", id: :serial, force: :cascade do |t|
+    t.integer "trial_id"
+    t.string "keyword"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_finder_trial_mesh_terms", force: :cascade do |t|
-    t.integer  "trial_id"
-    t.string   "mesh_term_type"
-    t.string   "mesh_term"
+  create_table "study_finder_trial_locations", id: :serial, force: :cascade do |t|
+    t.integer "trial_id"
+    t.integer "location_id"
+    t.string "status"
+    t.string "last_name"
+    t.string "phone"
+    t.string "email"
+    t.string "backup_last_name"
+    t.string "backup_phone"
+    t.string "backup_email"
+    t.string "investigator_last_name"
+    t.string "investigator_role"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_finder_trial_sites", force: :cascade do |t|
-    t.integer  "trial_id"
-    t.integer  "site_id"
+  create_table "study_finder_trial_mesh_terms", id: :serial, force: :cascade do |t|
+    t.integer "trial_id"
+    t.string "mesh_term_type"
+    t.string "mesh_term"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "study_finder_trial_sites", id: :serial, force: :cascade do |t|
+    t.integer "trial_id"
+    t.integer "site_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "study_finder_trials", force: :cascade do |t|
-    t.string   "system_id"
-    t.string   "brief_title",                 limit: 1000
-    t.string   "official_title",              limit: 4000
-    t.string   "acronym"
-    t.string   "phase"
-    t.string   "overall_status"
-    t.string   "source",                      limit: 1000
-    t.string   "verification_date"
-    t.text     "brief_summary"
-    t.text     "detailed_description"
-    t.string   "gender"
-    t.string   "minimum_age"
-    t.string   "maximum_age"
-    t.boolean  "healthy_volunteers"
-    t.string   "simple_description",          limit: 4000
-    t.string   "contact_override"
-    t.boolean  "visible"
-    t.boolean  "recruiting"
+  create_table "study_finder_trials", id: :serial, force: :cascade do |t|
+    t.string "system_id"
+    t.string "brief_title", limit: 1000
+    t.string "official_title", limit: 4000
+    t.string "acronym"
+    t.string "phase"
+    t.string "overall_status"
+    t.string "source", limit: 1000
+    t.string "verification_date"
+    t.text "brief_summary"
+    t.text "detailed_description"
+    t.string "gender"
+    t.string "minimum_age"
+    t.string "maximum_age"
+    t.boolean "healthy_volunteers"
+    t.string "simple_description", limit: 4000
+    t.string "contact_override"
+    t.boolean "visible"
+    t.boolean "recruiting"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "contact_override_first_name"
-    t.string   "contact_override_last_name"
-    t.integer  "parser_id"
-    t.string   "official_last_name"
-    t.string   "official_first_name"
-    t.string   "official_role"
-    t.string   "official_affiliation"
-    t.string   "contact_last_name"
-    t.string   "contact_first_name"
-    t.string   "contact_phone"
-    t.string   "contact_email"
-    t.string   "contact_backup_last_name"
-    t.string   "contact_backup_first_name"
-    t.string   "contact_backup_phone"
-    t.string   "contact_backup_email"
-    t.text     "eligibility_criteria"
-    t.string   "recruitment_url"
-    t.string   "min_age_unit"
-    t.string   "max_age_unit"
-    t.string   "lastchanged_date"
-    t.string   "firstreceived_date"
-    t.boolean  "reviewed"
-    t.integer  "featured",                                 default: 0
-    t.string   "irb_number"
-    t.string   "cancer_yn"
-    t.string   "pi_name"
-    t.string   "pi_id"
+    t.string "contact_override_first_name"
+    t.string "contact_override_last_name"
+    t.integer "parser_id"
+    t.string "official_last_name"
+    t.string "official_first_name"
+    t.string "official_role"
+    t.string "official_affiliation"
+    t.string "contact_last_name"
+    t.string "contact_first_name"
+    t.string "contact_phone"
+    t.string "contact_email"
+    t.string "contact_backup_last_name"
+    t.string "contact_backup_first_name"
+    t.string "contact_backup_phone"
+    t.string "contact_backup_email"
+    t.text "eligibility_criteria"
+    t.string "recruitment_url"
+    t.string "min_age_unit"
+    t.string "max_age_unit"
+    t.string "lastchanged_date"
+    t.string "firstreceived_date"
+    t.boolean "reviewed"
+    t.integer "featured", default: 0
+    t.string "irb_number"
+    t.string "cancer_yn"
+    t.string "pi_name"
+    t.string "pi_id"
   end
 
-  create_table "study_finder_updaters", force: :cascade do |t|
-    t.integer  "parser_id"
-    t.integer  "num_updated"
+  create_table "study_finder_updaters", id: :serial, force: :cascade do |t|
+    t.integer "parser_id"
+    t.integer "num_updated"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_finder_users", force: :cascade do |t|
-    t.string   "email",           default: "", null: false
-    t.integer  "sign_in_count",   default: 0,  null: false
+  create_table "study_finder_users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "last_sign_in_at"
-    t.string   "last_sign_in_ip"
-    t.string   "internet_id",     default: "", null: false
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "phone"
+    t.string "last_sign_in_ip"
+    t.string "internet_id", default: "", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.string "phone"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["email"], name: "index_study_finder_users_on_email", unique: true
+    t.index ["internet_id"], name: "index_study_finder_users_on_internet_id", unique: true
   end
-
-  add_index "study_finder_users", ["email"], name: "index_study_finder_users_on_email", unique: true, using: :btree
-  add_index "study_finder_users", ["internet_id"], name: "index_study_finder_users_on_internet_id", unique: true, using: :btree
 
 end


### PR DESCRIPTION
This adds a new option in the system administration section to indicate
whether trial keywords should be displayed in search results. This
defaults to `true` to maintain backward compatibility.

When this option is set to `false` keywords are still stored and used
for searches, but they are not displayed in results.

Note that because search results are the only place in the application
that these keywords are displayed, if this option is turned off you
can't view a trial's keywords (even in the admin interface). We may
eventually want to add an administrative trial view so keywords (and
all associated trial data) can be viewed by system administrators.