### PR TITLE
Fix nil keywords

### DIFF
--- a/app/models/study_finder/trial.rb
+++ b/app/models/study_finder/trial.rb
@@ -89,7 +89,7 @@ class StudyFinder::Trial < ApplicationRecord
 
   def keyword_suggest
     {
-      input: trial_keywords.map { |k| k.keyword.downcase }
+      input: trial_keywords.where.not(keyword: nil).map { |k| k.keyword.downcase }
     }
   end
 


### PR DESCRIPTION
This prevent elasticsearch from trying to index keyword rows that don't actually have a keyword.