### PR TITLE
Fix saving of Groups/Subgroups

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -47,16 +47,12 @@ class Admin::GroupsController < ApplicationController
     params[:adults] = false if params[:adults].nil?
     params[:healthy_volunteers] = false if params[:healthy_volunteers].nil?
 
+    @group.subgroups = params[:tags].to_s.split(',').map do |subgroup|
+      @group.subgroups.build(name: subgroup)
+    end
+    @group.save
+
     if @group.update(group_params)
-      unless params[:tags].nil?
-        StudyFinder::Subgroup.delete_all({ group_id: @group.id })
-        params[:tags][0].split(',').each do |t|
-          StudyFinder::Subgroup.create!({
-            group_id: @group.id,
-            name: t
-          })
-        end
-      end
       redirect_to edit_admin_group_path(params[:id]), flash: { success: 'Group updated successfully' }
     else
       render 'edit'

--- a/app/views/admin/groups/_form.html.haml
+++ b/app/views/admin/groups/_form.html.haml
@@ -6,7 +6,7 @@
 =# f.association :conditions, collection: @conditions, label_method: :condition, value_method: :id, label: 'Choose all conditions that apply', input_html: { class: 'select2' }, wrapper: false
 .form-group
   %label Subgroup
-  %input#tags.select2.tags{ type: 'hidden', value: f.object.subgroups.map { |g| g.name }.join(','), name: 'tags[]' }
+  %input#tags.select2.tags{ type: 'hidden', value: f.object.subgroups.map { |g| g.name }.join(','), name: 'tags' }
 
 %hr
  

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -54,5 +54,22 @@ RSpec.describe Admin::GroupsController, :type => :controller do
       expect( redirect_to @group )
     end
 
+    it "adds a new subgroup" do
+      put :update, params: { id: @group, tags: "This is a subgroup, And so is this, And this one too"}
+      expect( redirect_to @group )
+      expect(@group.subgroups.count).to eq(3)
+    end
+
+    it "removes a subgroup" do
+      put :update, params: { id: @group, tags: "This is a subgroup" }
+      expect( redirect_to @group )
+      expect(@group.subgroups.count).to eq(1)
+    end
+
+    it "removes all subgroups" do
+      put :update, params: { id: @group, tags: "" }
+      expect( redirect_to @group )
+      expect(@group.subgroups).to be_empty
+    end
   end
 end


### PR DESCRIPTION
This reworks the subgroup saving. It was using the deprecated form of
`delete_all`. `delete_all` has been removed altogether because the
existing code had a few other issues:

- Subgroups would not save if nothing else on the group changed.
- Subgroup saving was wrapped in `params[:tags].nil?` but this is never
the case in the real world. Empty tags came through as `[""]`.

This change builds up the set of subgroups on every save and calls an
explicit `save` on the parent Group. I'd rather have used nested
attributes on this, but didn't want to spend time reworking the select2
interface.