### PR TITLE
Update js responses for emails

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -67,7 +67,8 @@ class StudiesController < ApplicationController
         @system_info
       ).deliver
     end
-    render nothing: true
+
+    head :ok
   end
 
   def email_me
@@ -84,8 +85,8 @@ class StudiesController < ApplicationController
     if should_send
       StudyMailer.email_me(params[:email], params[:notes], @trial, contacts, eligibility, age).deliver
     end
-    
-    render nothing: true
+
+    head :ok
   end
 
   private


### PR DESCRIPTION
This was missed in the Rails upgrade from 4.2. `head :ok` is now preferred over `render nothing: true` for producing an HTTP 200 header-only response. `render nothing: true` was looking for a template and was returning an error because none exists for this route.