### PR TITLE
Don't clear Condition and ConditionGroup on reload_all

### DIFF
--- a/lib/connectors/ctgov.rb
+++ b/lib/connectors/ctgov.rb
@@ -86,8 +86,6 @@ module Connectors
       StudyFinder::TrialLocation.delete_all
       StudyFinder::TrialKeyword.delete_all
       StudyFinder::Location.delete_all
-      StudyFinder::Condition.delete_all
-      StudyFinder::ConditionGroup.delete_all
       StudyFinder::Trial.delete_all
       StudyFinder::TrialCondition.delete_all
     end


### PR DESCRIPTION
The `studyfinder:ctgov:reload_all` task is meant to throw away all
studies and reload all history from clinicaltrials.gov. Since
Condition/Group mappings are completely standalone, this operation also
throws away any time-consuming manual entry that has been done. This
data is completely separate from study data, so it seems better to have
it remain even when studies are fully reloaded from source.