### PR TITLE
Remove StudyFinder base inheritance

### DIFF
--- a/app/controllers/admin/conditions_controller.rb
+++ b/app/controllers/admin/conditions_controller.rb
@@ -5,7 +5,7 @@ class Admin::ConditionsController < ApplicationController
 
   	@start_date = (params[:start_date].nil?) ? (DateTime.now - 30.days).strftime('%m/%d/%Y') : params[:start_date]
   	@end_date = (params[:end_date].nil?) ? DateTime.now.strftime('%m/%d/%Y') : params[:end_date]
-    @conditions = StudyFinder::Condition.find_range(@start_date, @end_date)
+    @conditions = Condition.find_range(@start_date, @end_date)
 
     add_breadcrumb 'Reports'
     add_breadcrumb 'Recent Conditions'

--- a/app/controllers/admin/disease_sites_controller.rb
+++ b/app/controllers/admin/disease_sites_controller.rb
@@ -2,19 +2,19 @@ class Admin::DiseaseSitesController < ApplicationController
   before_action :authorize_admin
   
   def index
-    @sites = StudyFinder::DiseaseSite.includes(:group).all
+    @sites = DiseaseSite.includes(:group).all
     add_breadcrumb 'Disease Site'
   end
 
   def new
-    @site = StudyFinder::DiseaseSite.new
+    @site = DiseaseSite.new
 
     add_breadcrumb 'Disease Site', :admin_disease_sites_path
     add_breadcrumb 'Add Disease Site'
   end
 
   def create
-    @site = StudyFinder::DiseaseSite.new(site_params)
+    @site = DiseaseSite.new(site_params)
     if @site.save(@site)
       redirect_to admin_disease_sites_path, flash: { success: 'Site added successfully' }
     else
@@ -23,13 +23,13 @@ class Admin::DiseaseSitesController < ApplicationController
   end
 
   def edit
-    @site = StudyFinder::DiseaseSite.find(params[:id])
+    @site = DiseaseSite.find(params[:id])
     add_breadcrumb 'Disease Sites', :admin_disease_sites_path
     add_breadcrumb 'Edit Site'
   end
 
   def update
-    @site = StudyFinder::DiseaseSite.find(params[:id])
+    @site = DiseaseSite.find(params[:id])
 
     if @site.update(site_params)
       redirect_to edit_admin_disease_site_path(params[:id]), flash: { success: 'Site updated successfully' }
@@ -39,7 +39,7 @@ class Admin::DiseaseSitesController < ApplicationController
   end
 
   def destroy
-    @site = StudyFinder::DiseaseSite.find(params[:id])
+    @site = DiseaseSite.find(params[:id])
     if @site.destroy
       redirect_to admin_disease_sites_path, flash: { success: 'Site removed successfully' }
     else

--- a/app/controllers/admin/disease_sites_controller.rb
+++ b/app/controllers/admin/disease_sites_controller.rb
@@ -50,7 +50,7 @@ class Admin::DiseaseSitesController < ApplicationController
   
   private
     def site_params
-      params.require(:study_finder_disease_site).permit(:disease_site_name, :group_id)
+      params.require(:disease_site).permit(:disease_site_name, :group_id)
     end
 
 end

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -4,21 +4,21 @@ class Admin::GroupsController < ApplicationController
   require 'csv'
   
   def index
-    @groups = StudyFinder::Group.all
+    @groups = Group.all
 
     add_breadcrumb 'Groups'
   end
 
   def new
-    @group = StudyFinder::Group.new
-    @conditions = StudyFinder::Condition.all.order(:condition)
+    @group = Group.new
+    @conditions = Condition.all.order(:condition)
 
     add_breadcrumb 'Groups', :admin_groups_path
     add_breadcrumb 'Add Group'
   end
 
   def create
-    @group = StudyFinder::Group.new(group_params)
+    @group = Group.new(group_params)
     if @group.save(@group)
       redirect_to admin_groups_path, flash: { success: 'Group added successfully' }
     else
@@ -27,8 +27,8 @@ class Admin::GroupsController < ApplicationController
   end
 
   def edit
-    @group = StudyFinder::Group.find(params[:id])
-    @conditions = StudyFinder::Condition.all.order(:condition)
+    @group = Group.find(params[:id])
+    @conditions = Condition.all.order(:condition)
     
     add_breadcrumb 'Groups', :admin_groups_path
     add_breadcrumb 'Edit Group'
@@ -40,7 +40,7 @@ class Admin::GroupsController < ApplicationController
   end
 
   def update
-    @group = StudyFinder::Group.find(params[:id])
+    @group = Group.find(params[:id])
     
     params[:condition_ids] = [] if params[:condition_ids].nil?
     params[:children] = false if params[:children].nil?
@@ -60,7 +60,7 @@ class Admin::GroupsController < ApplicationController
   end
 
   def destroy
-    @group = StudyFinder::Group.find(params[:id])
+    @group = Group.find(params[:id])
     if @group.destroy
       redirect_to admin_groups_path, flash: { success: 'Group removed successfully' }
     else
@@ -69,7 +69,7 @@ class Admin::GroupsController < ApplicationController
   end
 
   def reindex
-    StudyFinder::Trial.import force: true
+    Trial.import force: true
 
     add_breadcrumb 'Groups', :admin_groups_path
   end

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -2,20 +2,20 @@ class Admin::SitesController < ApplicationController
   before_action :authorize_admin
   
   def index
-    @sites = StudyFinder::Site.all
+    @sites = Site.all
 
     add_breadcrumb 'Sites'
   end
 
   def new
-    @site = StudyFinder::Site.new
+    @site = Site.new
 
     add_breadcrumb 'Sites', :admin_sites_path
     add_breadcrumb 'Add Site'
   end
 
   def create
-    @site = StudyFinder::Site.new(site_params)
+    @site = Site.new(site_params)
     if @site.save(@site)
       redirect_to admin_sites_path, flash: { success: 'Site added successfully' }
     else
@@ -24,13 +24,13 @@ class Admin::SitesController < ApplicationController
   end
 
   def edit
-    @site = StudyFinder::Site.find(params[:id])
+    @site = Site.find(params[:id])
     add_breadcrumb 'Sites', :admin_sites_path
     add_breadcrumb 'Edit Site'
   end
 
   def update
-    @site = StudyFinder::Site.find(params[:id])
+    @site = Site.find(params[:id])
 
     if @site.update(site_params)
       redirect_to edit_admin_site_path(params[:id]), flash: { success: 'Site updated successfully' }
@@ -40,7 +40,7 @@ class Admin::SitesController < ApplicationController
   end
 
   def destroy
-    @site = StudyFinder::Site.find(params[:id])
+    @site = Site.find(params[:id])
     if @site.destroy
       redirect_to admin_sites_path, flash: { success: 'Site removed successfully' }
     else

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -50,6 +50,6 @@ class Admin::SitesController < ApplicationController
 
   private
     def site_params
-      params.require(:study_finder_site).permit(:site_name, :address, :city, :state, :zip)
+      params.require(:site).permit(:site_name, :address, :city, :state, :zip)
     end
 end

--- a/app/controllers/admin/system_controller.rb
+++ b/app/controllers/admin/system_controller.rb
@@ -26,7 +26,7 @@ class Admin::SystemController < ApplicationController
 
   private
     def system_params
-      params.require(:study_finder_system_info).permit(
+      params.require(:system_info).permit(
         :initials,
         :school_name,
         :system_name,

--- a/app/controllers/admin/system_controller.rb
+++ b/app/controllers/admin/system_controller.rb
@@ -2,20 +2,20 @@ class Admin::SystemController < ApplicationController
   before_action :authorize_admin
   
   def index
-    @system = StudyFinder::SystemInfo.current
+    @system = SystemInfo.current
     redirect_to edit_admin_system_path(@system.id)
   end
 
   def edit
-    @system = StudyFinder::SystemInfo.find(params[:id])
-    @updated = StudyFinder::Updater.all.last
+    @system = SystemInfo.find(params[:id])
+    @updated = Updater.all.last
 
     add_breadcrumb 'System Administration'
   end
 
   def update
-    @system = StudyFinder::SystemInfo.find(params[:id])
-    @updated = StudyFinder::Updater.all.last
+    @system = SystemInfo.find(params[:id])
+    @updated = Updater.all.last
     
     if @system.update(system_params)
       redirect_to edit_admin_system_path(params[:id]), flash: { success: 'System information updated successfully' }

--- a/app/controllers/admin/trials_controller.rb
+++ b/app/controllers/admin/trials_controller.rb
@@ -13,11 +13,11 @@ class Admin::TrialsController < ApplicationController
   end
 
   def preview
-    if params.has_key?('study_finder_trial') && params[:study_finder_trial].has_key?('system_id') && !params[:study_finder_trial][:system_id].blank?
-      @trial = Trial.find_by(system_id: params[:study_finder_trial][:system_id])
+    if params.has_key?('trial') && params[:trial].has_key?('system_id') && !params[:trial][:system_id].blank?
+      @trial = Trial.find_by(system_id: params[:trial][:system_id])
 
       if @trial.nil?
-        parser = Parsers::Ctgov.new(params[:study_finder_trial][:system_id]) # initialize the parser
+        parser = Parsers::Ctgov.new(params[:trial][:system_id]) # initialize the parser
         parser.load # call the api and load the xml response
         @preview = parser.preview # preview the simple fields
       else
@@ -39,7 +39,7 @@ class Admin::TrialsController < ApplicationController
   end
 
   def create
-    trial = Parsers::Ctgov.new(params[:study_finder_trial][:system_id])
+    trial = Parsers::Ctgov.new(params[:trial][:system_id])
     trial.load
     trial.process
 
@@ -66,7 +66,7 @@ class Admin::TrialsController < ApplicationController
 
       format.xls do
         response.headers['Content-Type'] = 'application/vnd.ms-excel'
-        response.headers['Content-Disposition'] = "attachment; filename=\"study_finder_trials_#{DateTime.now}.xls\""
+        response.headers['Content-Disposition'] = "attachment; filename=\"trials_#{DateTime.now}.xls\""
         render "recent_as.xls.erb"
       end
     end
@@ -116,7 +116,7 @@ class Admin::TrialsController < ApplicationController
 
   private
     def trial_params
-      params.require(:study_finder_trial).permit(
+      params.require(:trial).permit(
         :simple_description, :visible, 
         :featured, :recruiting, :contact_override, :cancer_yn,
         :contact_override_first_name, :contact_override_last_name, :pi_name, :pi_id, :recruitment_url, 

--- a/app/controllers/admin/trials_controller.rb
+++ b/app/controllers/admin/trials_controller.rb
@@ -5,7 +5,7 @@ class Admin::TrialsController < ApplicationController
   require 'parsers/oncore'
 
   def new
-    @trial = StudyFinder::Trial.new
+    @trial = Trial.new
     @systems = ['Ctgov', 'Oncore']
 
     add_breadcrumb 'Trials Administration', :admin_trials_path
@@ -14,7 +14,7 @@ class Admin::TrialsController < ApplicationController
 
   def preview
     if params.has_key?('study_finder_trial') && params[:study_finder_trial].has_key?('system_id') && !params[:study_finder_trial][:system_id].blank?
-      @trial = StudyFinder::Trial.find_by(system_id: params[:study_finder_trial][:system_id])
+      @trial = Trial.find_by(system_id: params[:study_finder_trial][:system_id])
 
       if @trial.nil?
         parser = Parsers::Ctgov.new(params[:study_finder_trial][:system_id]) # initialize the parser
@@ -32,7 +32,7 @@ class Admin::TrialsController < ApplicationController
   end
 
   def import
-    StudyFinder::Trial.import_from_file(params[:file])
+    Trial.import_from_file(params[:file])
     redirect_to admin_trials_import_path, notice: "Trials Imported"
   rescue => e
     redirect_to admin_trials_import_path, alert: "Some trials may have failed to import: #{e}"
@@ -47,7 +47,7 @@ class Admin::TrialsController < ApplicationController
   end
 
   def review
-    @trial = StudyFinder::Trial.find_by(system_id: params[:id])
+    @trial = Trial.find_by(system_id: params[:id])
     @trial.reviewed = true
     @trial.save!
     redirect_to admin_trial_recent_as_path
@@ -56,7 +56,7 @@ class Admin::TrialsController < ApplicationController
   def recent_as
     @start_date = (params[:start_date].nil?) ? (DateTime.now - 30.days).strftime('%m/%d/%Y') : params[:start_date]
     @end_date = (params[:end_date].nil?) ? DateTime.now.strftime('%m/%d/%Y') : params[:end_date]
-    @trials = StudyFinder::Trial.includes(:disease_sites).find_range(@start_date, @end_date)
+    @trials = Trial.includes(:disease_sites).find_range(@start_date, @end_date)
 
     add_breadcrumb 'Trials Administration'
     add_breadcrumb 'Recently Added'
@@ -74,9 +74,9 @@ class Admin::TrialsController < ApplicationController
 
   def index
     unless params[:q].nil?
-      @trials = StudyFinder::Trial.match_all_admin({ q: params[:q] }).page(params[:page]).records
+      @trials = Trial.match_all_admin({ q: params[:q] }).page(params[:page]).records
     else
-      @trials = StudyFinder::Trial.paginate(page: params[:page])
+      @trials = Trial.paginate(page: params[:page])
     end
 
     add_breadcrumb 'Trials Administration'
@@ -89,13 +89,13 @@ class Admin::TrialsController < ApplicationController
     trial.load
     trial.process
 
-    @trial = StudyFinder::Trial.find_by(system_id: params[:id])
+    @trial = Trial.find_by(system_id: params[:id])
 
     if @trial.nil?
       redirect_to admin_trials_path, alert: 'This trial does not exist'
     end
 
-    if @trial.parser.klass == 'Parsers::Ctgov' && !StudyFinder::Parser.find_by({ klass: 'Parsers::Oncore'}).blank?
+    if @trial.parser.klass == 'Parsers::Ctgov' && !Parser.find_by({ klass: 'Parsers::Oncore'}).blank?
       @oncore = Parsers::Oncore.new(@trial.system_id)
       @oncore.load(true)
     end
@@ -105,7 +105,7 @@ class Admin::TrialsController < ApplicationController
   end
 
   def update
-    @trial = StudyFinder::Trial.find_by(system_id: params[:id])
+    @trial = Trial.find_by(system_id: params[:id])
 
     if @trial.update(trial_params)
       redirect_to edit_admin_trial_path(params[:id]), flash: { success: 'Trial updated successfully' }

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,20 +2,20 @@ class Admin::UsersController < ApplicationController
   before_action :authorize_admin
   
   def index
-    @users = StudyFinder::User.all
+    @users = User.all
 
     add_breadcrumb 'Users'
   end
 
   def new
-    @user = StudyFinder::User.new
+    @user = User.new
 
     add_breadcrumb 'Users', :admin_users_path
     add_breadcrumb 'Add User'
   end
 
   def create
-    @user = StudyFinder::User.new(user_params)
+    @user = User.new(user_params)
 
     if @user.save(@user)
       redirect_to admin_users_path, flash: { success: 'User added successfully' }
@@ -25,14 +25,14 @@ class Admin::UsersController < ApplicationController
   end
 
   def edit
-    @user = StudyFinder::User.find(params[:id])
+    @user = User.find(params[:id])
     
     add_breadcrumb 'Users', :admin_users_path
     add_breadcrumb 'Edit User'
   end
 
   def update
-    @user = StudyFinder::User.find(params[:id])
+    @user = User.find(params[:id])
     if @user.update(user_params)
       redirect_to edit_admin_user_path(params[:id]), flash: { success: 'User updated successfully' }
     else
@@ -41,7 +41,7 @@ class Admin::UsersController < ApplicationController
   end
 
   def destroy
-    @user = StudyFinder::User.find(params[:id])
+    @user = User.find(params[:id])
     if @user.destroy
       redirect_to admin_users_path, flash: { success: 'User removed successfully' }
     else

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -51,6 +51,6 @@ class Admin::UsersController < ApplicationController
 
   private
     def user_params
-      params.require(:study_finder_user).permit(:email, :internet_id, :first_name, :last_name, :phone)
+      params.require(:user).permit(:email, :internet_id, :first_name, :last_name, :phone)
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,6 @@ class ApplicationController < ActionController::Base
 
   private
     def system
-      @system_info = StudyFinder::SystemInfo.current
+      @system_info = SystemInfo.current
     end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,5 @@
 class CategoriesController < ApplicationController
   def index
-    @groups = StudyFinder::Group.order(:group_name).all
+    @groups = Group.order(:group_name).all
   end
 end

--- a/app/controllers/researchers_controller.rb
+++ b/app/controllers/researchers_controller.rb
@@ -16,7 +16,7 @@ class ResearchersController < ApplicationController
   end
 
   def edit
-    @trial = StudyFinder::Trial.find_by(system_id: params[:id])
+    @trial = Trial.find_by(system_id: params[:id])
 
     add_breadcrumb 'Home', :root_path
     add_breadcrumb 'For Researchers', :researchers_path
@@ -25,7 +25,7 @@ class ResearchersController < ApplicationController
   end
 
   def update
-    @trial = StudyFinder::Trial.find_by(system_id: params[:id])
+    @trial = Trial.find_by(system_id: params[:id])
 
     if !params[:secret_key].blank? && params[:secret_key] == @system_info.secret_key
       if @trial.update(trial_params)
@@ -41,7 +41,7 @@ class ResearchersController < ApplicationController
   end
 
   def search_results
-    trial = StudyFinder::Trial.find_by(system_id: params[:id])
+    trial = Trial.find_by(system_id: params[:id])
 
     if trial.nil?
       redirect_to search_trials_researchers_path, flash: { error: 'Trial does not exist in the system' }

--- a/app/controllers/researchers_controller.rb
+++ b/app/controllers/researchers_controller.rb
@@ -52,7 +52,7 @@ class ResearchersController < ApplicationController
 
   private
     def trial_params
-      params.require(:study_finder_trial).permit(:simple_description, :contact_override, :contact_override_first_name, :contact_override_last_name)
+      params.require(:trial).permit(:simple_description, :contact_override, :contact_override_first_name, :contact_override_last_name)
     end
 
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,7 +3,7 @@ class SearchController < ApplicationController
     response.headers.delete "X-Frame-Options" # Allow only this page to be available in an iframe.
     
     unless params[:group].nil?
-      @category = StudyFinder::Group.find_by(group_name: params[:group]) 
+      @category = Group.find_by(group_name: params[:group]) 
     end
 
     render 'embed', layout: 'embed'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,13 +6,13 @@ class SessionsController < ApplicationController
   end
 
   def create
-    ldap = Modules::Ldap.new.authenticate(params[:study_finder_user][:internet_id], params[:study_finder_user][:password])
+    ldap = Modules::Ldap.new.authenticate(params[:user][:internet_id], params[:user][:password])
 
     # passed ldap authentication, still need to have an account in Study Finder
     if ldap[:success] == true
 
       # look the user up in Study Finder
-      user = User.find_by(internet_id: params[:study_finder_user][:internet_id])
+      user = User.find_by(internet_id: params[:user][:internet_id])
 
       # user has an account in Study Finder, set them to admin
       unless user.nil?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@ class SessionsController < ApplicationController
   require 'modules/ldap'
 
   def new
-    @user = StudyFinder::User.new
+    @user = User.new
   end
 
   def create
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
     if ldap[:success] == true
 
       # look the user up in Study Finder
-      user = StudyFinder::User.find_by(internet_id: params[:study_finder_user][:internet_id])
+      user = User.find_by(internet_id: params[:study_finder_user][:internet_id])
 
       # user has an account in Study Finder, set them to admin
       unless user.nil?
@@ -30,7 +30,7 @@ class SessionsController < ApplicationController
       else
         # stuff the ldap info into a user model to be stored in the session
         # logger.debug ldap[:ldap_user].cn.first.to_s
-        researcher = StudyFinder::User.new
+        researcher = User.new
         researcher.internet_id = ldap[:ldap_user].uid.first
         researcher.first_name = ldap[:ldap_user].givenname.first
         researcher.last_name = ldap[:ldap_user].sn.first

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -7,7 +7,7 @@ class StudiesController < ApplicationController
     search_parameters = params[:search].deep_dup if !params[:search].nil?
 
     if !params[:search].nil? and !params[:search][:category].nil?
-      @group = StudyFinder::Group.find(params[:search][:category])
+      @group = Group.find(params[:search][:category])
       
       if @group.conditions_empty?
         search_parameters = search_parameters.except!(:category)
@@ -17,25 +17,25 @@ class StudiesController < ApplicationController
     if params[:search].nil? or params[:search][:q].blank?
       # Show all trials that are visible, there were no search terms entered.
       search_parameters = {} if search_parameters.nil?
-      @trials = StudyFinder::Trial.match_all(search_parameters).page(params[:page]).results
+      @trials = Trial.match_all(search_parameters).page(params[:page]).results
     else
       # There is actually a search term here.
-      # phrase_search = StudyFinder::Trial.phrase_search(params[:search]).page(params[:page]).results
+      # phrase_search = Trial.phrase_search(params[:search]).page(params[:page]).results
       # unless phrase_search.total == 0
       #   @trials = phrase_search
       # else
         params[:search][:q] = replace_words(search_parameters[:q])
         search_parameters[:q] = params[:search][:q]
 
-        @trials = StudyFinder::Trial.match_all_search(search_parameters).page(params[:page]).results
+        @trials = Trial.match_all_search(search_parameters).page(params[:page]).results
         # if match_all.total == 0
-        #   @trials = StudyFinder::Trial.match_synonyms(params[:search]).page(params[:page]).results
+        #   @trials = Trial.match_synonyms(params[:search]).page(params[:page]).results
         # else
         #   @trials = match_all
         # end  
       # end
       if @trials.total == 0
-        @suggestions = StudyFinder::Trial.suggestions(search_parameters[:q])
+        @suggestions = Trial.suggestions(search_parameters[:q])
       end
     end
 
@@ -43,12 +43,12 @@ class StudiesController < ApplicationController
   end
 
   def typeahead
-    typeahead = StudyFinder::Trial.typeahead(params[:q])
+    typeahead = Trial.typeahead(params[:q])
     respond_with(typeahead['suggest']['keyword_suggest'][0]['options'])
   end
 
   def contact_team
-    @trial = StudyFinder::Trial.find params[:id]
+    @trial = Trial.find params[:id]
     should_send = true
 
     if @system_info.captcha
@@ -72,7 +72,7 @@ class StudiesController < ApplicationController
   end
 
   def email_me
-    @trial = StudyFinder::Trial.find params[:id]
+    @trial = Trial.find params[:id]
     contacts = contacts_display(determine_contacts(@trial))
     eligibility = eligibility_display(@trial.gender)
     age = age_display(@trial.min_age, @trial.max_age)

--- a/app/mailers/contact_form.rb
+++ b/app/mailers/contact_form.rb
@@ -4,7 +4,7 @@ class ContactForm < MailForm::Base
   attribute :message, validate: true
 
   def headers
-    system_info = StudyFinder::SystemInfo.current
+    system_info = SystemInfo.current
     {
       subject: 'Study Finder - Contact Us',
       to: system_info.default_email,

--- a/app/mailers/study_mailer.rb
+++ b/app/mailers/study_mailer.rb
@@ -23,7 +23,7 @@ class StudyMailer < ActionMailer::Base
     @age = age
     @conditions = @trial.conditions_map
     @interventions = @trial.interventions
-    system_info = StudyFinder::SystemInfo.current
+    system_info = SystemInfo.current
 
     mail(from: system_info.default_email, to: email, reply_to: email, subject: "StudyFinder - #{trial.brief_title}")
   end

--- a/app/models/base_trial.rb
+++ b/app/models/base_trial.rb
@@ -1,4 +1,4 @@
-class StudyFinder::BaseTrial < ApplicationRecord
+class BaseTrial < ApplicationRecord
   self.table_name = 'study_finder_trials'
 
   belongs_to :parser
@@ -51,6 +51,6 @@ class StudyFinder::BaseTrial < ApplicationRecord
   end
 
   def category_ids
-    StudyFinder::VwStudyFinderTrialGroups.where({ trial_id: id }).map(&:group_id)
+    VwStudyFinderTrialGroups.where({ trial_id: id }).map(&:group_id)
   end
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,4 +1,4 @@
-class StudyFinder::Condition < ApplicationRecord
+class Condition < ApplicationRecord
   self.table_name = 'study_finder_conditions'
 
   scope :recent_as, ->(duration){ where('created_at > ?', Time.zone.today - duration ).order('created_at DESC') }

--- a/app/models/condition_group.rb
+++ b/app/models/condition_group.rb
@@ -1,4 +1,4 @@
-class StudyFinder::ConditionGroup < ApplicationRecord
+class ConditionGroup < ApplicationRecord
   self.table_name = 'study_finder_condition_groups'
 
   belongs_to :condition

--- a/app/models/disease_site.rb
+++ b/app/models/disease_site.rb
@@ -1,4 +1,4 @@
-class StudyFinder::DiseaseSite < ApplicationRecord
+class DiseaseSite < ApplicationRecord
   self.table_name = 'study_finder_disease_sites'
 
   belongs_to :group

--- a/app/models/ds_trial.rb
+++ b/app/models/ds_trial.rb
@@ -1,4 +1,4 @@
-class StudyFinder::DsTrial < ApplicationRecord
+class DsTrial < ApplicationRecord
   self.table_name = 'study_finder_ds_trials'
 
   belongs_to :trial

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,4 @@
-class StudyFinder::Group < ApplicationRecord
+class Group < ApplicationRecord
   self.table_name = 'study_finder_groups'
 
   validates :group_name, presence: true
@@ -22,9 +22,9 @@ class StudyFinder::Group < ApplicationRecord
 
   def study_count
     if conditions_empty?
-      count = StudyFinder::Trial.match_all(apply_filters).results.total
+      count = Trial.match_all(apply_filters).results.total
     else
-      count = StudyFinder::VwGroupTrialCount.where({ id: id }).first.trial_count.to_i
+      count = VwGroupTrialCount.where({ id: id }).first.trial_count.to_i
     end
 
     count

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,3 +1,3 @@
-class StudyFinder::Location < ApplicationRecord
+class Location < ApplicationRecord
   self.table_name = 'study_finder_locations'
 end

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -1,3 +1,3 @@
-class StudyFinder::Parser < ApplicationRecord
+class Parser < ApplicationRecord
   self.table_name = 'study_finder_parsers'
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,4 +1,4 @@
-class StudyFinder::Site < ApplicationRecord
+class Site < ApplicationRecord
   self.table_name = 'study_finder_sites'
 
   validates :site_name, presence: true

--- a/app/models/study_finder.rb
+++ b/app/models/study_finder.rb
@@ -1,5 +1,0 @@
-module StudyFinder
-  def self.table_name_prefix
-    'study_finder_'
-  end
-end

--- a/app/models/study_finder/trial_intervention.rb
+++ b/app/models/study_finder/trial_intervention.rb
@@ -1,3 +1,0 @@
-class StudyFinder::TrialIntervention < ApplicationRecord
-  self.table_name = 'study_finder_trial_intervents'
-end

--- a/app/models/study_finder/vw_group_trial_count.rb
+++ b/app/models/study_finder/vw_group_trial_count.rb
@@ -1,3 +1,0 @@
-class StudyFinder::VwGroupTrialCount < ApplicationRecord
-  self.table_name = 'vw_study_finder_trial_counts'
-end

--- a/app/models/study_finder/vw_study_finder_trial_groups.rb
+++ b/app/models/study_finder/vw_study_finder_trial_groups.rb
@@ -1,3 +1,0 @@
-class StudyFinder::VwStudyFinderTrialGroups < ApplicationRecord
-  self.table_name = 'vw_study_finder_trial_groups'
-end

--- a/app/models/subgroup.rb
+++ b/app/models/subgroup.rb
@@ -1,4 +1,4 @@
-class StudyFinder::Subgroup < ApplicationRecord
+class Subgroup < ApplicationRecord
   self.table_name = 'study_finder_subgroups'
   belongs_to :group
 end

--- a/app/models/system_info.rb
+++ b/app/models/system_info.rb
@@ -1,4 +1,4 @@
-class StudyFinder::SystemInfo < ApplicationRecord
+class SystemInfo < ApplicationRecord
   self.table_name = 'study_finder_system_infos'
 
   validates_presence_of :secret_key, :default_email, :initials, :school_name

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -1,4 +1,4 @@
-class StudyFinder::Trial < ApplicationRecord
+class Trial < ApplicationRecord
 
   require 'csv'
 
@@ -31,7 +31,7 @@ class StudyFinder::Trial < ApplicationRecord
 
   def self.import_from_file(file)
     CSV.foreach(file.path, headers: true) do |row|
-      StudyFinder::Trial.create! row.to_hash
+      Trial.create! row.to_hash
     end
   end
 
@@ -84,7 +84,7 @@ class StudyFinder::Trial < ApplicationRecord
   end
 
   def category_ids
-    StudyFinder::VwStudyFinderTrialGroups.where({ trial_id: id }).map(&:group_id)
+    VwStudyFinderTrialGroups.where({ trial_id: id }).map(&:group_id)
   end
 
   def keyword_suggest

--- a/app/models/trial_condition.rb
+++ b/app/models/trial_condition.rb
@@ -1,4 +1,4 @@
-class StudyFinder::TrialCondition < ApplicationRecord
+class TrialCondition < ApplicationRecord
   self.table_name = 'study_finder_trial_conditions'
   self.primary_key = :id
 

--- a/app/models/trial_intervention.rb
+++ b/app/models/trial_intervention.rb
@@ -1,0 +1,3 @@
+class TrialIntervention < ApplicationRecord
+  self.table_name = 'study_finder_trial_intervents'
+end

--- a/app/models/trial_keyword.rb
+++ b/app/models/trial_keyword.rb
@@ -1,3 +1,3 @@
-class StudyFinder::TrialKeyword < ApplicationRecord
+class TrialKeyword < ApplicationRecord
   self.table_name = 'study_finder_trial_keywords'
 end

--- a/app/models/trial_location.rb
+++ b/app/models/trial_location.rb
@@ -1,4 +1,4 @@
-class StudyFinder::TrialLocation < ApplicationRecord
+class TrialLocation < ApplicationRecord
   self.table_name = 'study_finder_trial_locations'
 
   belongs_to :location

--- a/app/models/trial_mesh_term.rb
+++ b/app/models/trial_mesh_term.rb
@@ -1,4 +1,4 @@
-class StudyFinder::TrialMeshTerm < ApplicationRecord
+class TrialMeshTerm < ApplicationRecord
   self.table_name = 'study_finder_trial_mesh_terms'
 
   belongs_to :trial

--- a/app/models/trial_site.rb
+++ b/app/models/trial_site.rb
@@ -1,4 +1,4 @@
-class StudyFinder::TrialSite < ApplicationRecord
+class TrialSite < ApplicationRecord
   self.table_name = 'study_finder_trial_sites'
 
   belongs_to :trial

--- a/app/models/updater.rb
+++ b/app/models/updater.rb
@@ -1,3 +1,3 @@
-class StudyFinder::Updater < ApplicationRecord
+class Updater < ApplicationRecord
   self.table_name = 'study_finder_updaters'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-class StudyFinder::User < ApplicationRecord
+class User < ApplicationRecord
   self.table_name = 'study_finder_users'
 
   validates :first_name, :last_name, :email, :internet_id, presence: true

--- a/app/models/vw_group_trial_count.rb
+++ b/app/models/vw_group_trial_count.rb
@@ -1,0 +1,3 @@
+class VwGroupTrialCount < ApplicationRecord
+  self.table_name = 'vw_study_finder_trial_counts'
+end

--- a/app/models/vw_study_finder_trial_groups.rb
+++ b/app/models/vw_study_finder_trial_groups.rb
@@ -1,0 +1,3 @@
+class VwStudyFinderTrialGroups < ApplicationRecord
+  self.table_name = 'vw_study_finder_trial_groups'
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,7 +31,7 @@ system = {
   contact_email_suffix: '@umn.edu'
 }
 
-system_info = StudyFinder::SystemInfo.find_or_initialize_by(initials: system[:initials])
+system_info = SystemInfo.find_or_initialize_by(initials: system[:initials])
 system_info.school_name = system[:school_name]
 system_info.system_name = system[:system_name]
 system_info.system_header = system[:system_header]
@@ -56,7 +56,7 @@ system_info.save!
     klass: 'Parsers::Ctgov'
   }
 ].each do |p|
-  parser = StudyFinder::Parser.find_or_initialize_by(name: p[:name])
+  parser = Parser.find_or_initialize_by(name: p[:name])
   parser.klass = p[:klass]
   parser.save!
 end
@@ -73,7 +73,7 @@ end
     email: "fake@example.edu"
   }
 ].each do |u|
-  user = StudyFinder::User.find_or_initialize_by(internet_id: u[:internet_id])
+  user = User.find_or_initialize_by(internet_id: u[:internet_id])
   user.first_name = u[:first_name]
   user.last_name = u[:last_name]
   user.email = u[:email]
@@ -85,9 +85,9 @@ end
 # ============================================
 
 CSV.foreach(Rails.root.join("db/seeds/condition_groups.csv")) do |group_name, condition_name|
-  group = StudyFinder::Group.find_or_create_by(group_name: group_name)
-  condition = StudyFinder::Condition.find_or_create_by(condition: condition_name)
-  StudyFinder::ConditionGroup.find_or_create_by(group: group, condition: condition)
+  group = Group.find_or_create_by(group_name: group_name)
+  condition = Condition.find_or_create_by(condition: condition_name)
+  ConditionGroup.find_or_create_by(group: group, condition: condition)
 end
 
 # ============================================

--- a/lib/connectors/ctgov.rb
+++ b/lib/connectors/ctgov.rb
@@ -4,8 +4,8 @@ module Connectors
     require 'zip'
 
     def initialize
-      @system_info = StudyFinder::SystemInfo.current
-      @parser_id = StudyFinder::Parser.find_by({ klass: 'Parsers::Ctgov'}).id
+      @system_info = SystemInfo.current
+      @parser_id = Parser.find_by({ klass: 'Parsers::Ctgov'}).id
 
       if @system_info.nil?
         raise "There is no system info associated. Please run the seeds file, or add the info in the system administration section."
@@ -70,7 +70,7 @@ module Connectors
       end_load_time = Time.now
 
       puts "Logging update to updaters table. Processed #{count} records."
-      StudyFinder::Updater.create({
+      Updater.create({
         parser_id: @parser_id,
         num_updated: count
       })
@@ -82,12 +82,12 @@ module Connectors
     def clear
       puts "Clearing out all the old trial tables."
 
-      StudyFinder::TrialIntervention.delete_all
-      StudyFinder::TrialLocation.delete_all
-      StudyFinder::TrialKeyword.delete_all
-      StudyFinder::Location.delete_all
-      StudyFinder::Trial.delete_all
-      StudyFinder::TrialCondition.delete_all
+      TrialIntervention.delete_all
+      TrialLocation.delete_all
+      TrialKeyword.delete_all
+      Location.delete_all
+      Trial.delete_all
+      TrialCondition.delete_all
     end
 
     private

--- a/lib/connectors/oncore.rb
+++ b/lib/connectors/oncore.rb
@@ -1,7 +1,7 @@
 module Connectors
   class Oncore
     def initialize
-      @system_info = StudyFinder::SystemInfo.current
+      @system_info = SystemInfo.current
       if @system_info.nil?
         raise "There is no system info associated. Please run the seeds file, or add the info in the system administration section."
       end

--- a/lib/parsers/ctgov.rb
+++ b/lib/parsers/ctgov.rb
@@ -42,7 +42,7 @@ module Parsers
     end
 
     def preview
-      trial = StudyFinder::Trial.new(system_id: @id)
+      trial = Trial.new(system_id: @id)
 
       retrieve_simple_fields(trial)
 
@@ -51,9 +51,9 @@ module Parsers
 
     def process(without_index=nil)
       if without_index.nil?
-        trial = StudyFinder::Trial.find_or_initialize_by(system_id: @id)
+        trial = Trial.find_or_initialize_by(system_id: @id)
       else
-        trial = StudyFinder::BaseTrial.find_or_initialize_by(system_id: @id)
+        trial = BaseTrial.find_or_initialize_by(system_id: @id)
       end
 
       
@@ -68,7 +68,7 @@ module Parsers
         end
 
         if @parser_id.nil?
-          trial.parser_id = StudyFinder::Parser.find_by({ klass: 'Parsers::Ctgov'}).id
+          trial.parser_id = Parser.find_by({ klass: 'Parsers::Ctgov'}).id
         else
           trial.parser_id = @parser_id
         end
@@ -204,7 +204,7 @@ module Parsers
     def process_mesh_term(trial)
       if (!@contents['conditional_browse'].nil? && @contents['conditional_browse'].has_key?('mesh_term')) || 
          (!@contents['intervention_browse'].nil? && @contents['intervention_browse'].has_key?('mesh_term')) 
-        StudyFinder::TrialMeshTerm.where(trial_id: trial.id).delete_all
+        TrialMeshTerm.where(trial_id: trial.id).delete_all
       end
       if !@contents['conditional_browse'].nil? && @contents['conditional_browse'].has_key?('mesh_term')
         process_condition_browse(trial)
@@ -219,7 +219,7 @@ module Parsers
       mesh_term = [mesh_term] unless mesh_term.instance_of?(Array)
 
       mesh_term.each do |mesh|
-        test = StudyFinder::TrialMeshTerm.create({
+        test = TrialMeshTerm.create({
           trial_id: trial.id,
           mesh_term_type: 'Conditional',
           mesh_term: mesh
@@ -232,7 +232,7 @@ module Parsers
       mesh_term = [mesh_term] unless mesh_term.instance_of?(Array)
 
       mesh_term.each do |mesh|
-        test = StudyFinder::TrialMeshTerm.create({
+        test = TrialMeshTerm.create({
           trial_id: trial.id,
           mesh_term_type: 'Intervention',
           mesh_term: mesh
@@ -244,15 +244,15 @@ module Parsers
       conditions = @contents['condition']
       conditions = [conditions] unless conditions.instance_of?(Array)
   
-      StudyFinder::TrialCondition.where(trial_id: id).delete_all
+      TrialCondition.where(trial_id: id).delete_all
 
       conditions.each do |c|
-        condition = StudyFinder::Condition.find_or_initialize_by(condition: c)
+        condition = Condition.find_or_initialize_by(condition: c)
         if condition.id.nil?
           condition.save
         end
 
-        StudyFinder::TrialCondition.create({
+        TrialCondition.create({
           trial_id: id,
           condition_id: condition.id
         })
@@ -263,10 +263,10 @@ module Parsers
       interventions = @contents['intervention']
       interventions = [interventions] unless interventions.instance_of?(Array)
 
-      StudyFinder::TrialIntervention.where(trial_id: id).delete_all
+      TrialIntervention.where(trial_id: id).delete_all
 
       interventions.each do |i|
-        StudyFinder::TrialIntervention.create({
+        TrialIntervention.create({
           trial_id: id,
           intervention_type: i['intervention_type'],
           intervention: i['intervention_name'],
@@ -279,11 +279,11 @@ module Parsers
       locations = @contents['location']
       locations = [locations] unless locations.instance_of?(Array)
 
-      StudyFinder::TrialLocation.where(trial_id: id).delete_all
+      TrialLocation.where(trial_id: id).delete_all
 
       locations.each do |l|
         facility = l['facility'] if l.has_key?('facility')
-        location = StudyFinder::Location.find_or_initialize_by(location: facility['name'])
+        location = Location.find_or_initialize_by(location: facility['name'])
         
         if facility.has_key?('address')
           address = facility['address']
@@ -322,7 +322,7 @@ module Parsers
           trial_location_hash['status'] = l['status']
         end
 
-        StudyFinder::TrialLocation.create(trial_location_hash)
+        TrialLocation.create(trial_location_hash)
       end
     end
 
@@ -331,10 +331,10 @@ module Parsers
       keywords = @contents['keyword']
       keywords = [keywords] unless keywords.instance_of?(Array)
 
-      StudyFinder::TrialKeyword.where(trial_id: id).delete_all
+      TrialKeyword.where(trial_id: id).delete_all
 
       keywords.each do |k|
-        StudyFinder::TrialKeyword.create({
+        TrialKeyword.create({
           trial_id: id,
           keyword: k
         })

--- a/lib/parsers/oncore.rb
+++ b/lib/parsers/oncore.rb
@@ -22,10 +22,10 @@ module Parsers
       oncore = @contents
 
       unless oncore['nct_id'].blank?
-        ctgov = StudyFinder::Trial.find_by(system_id: oncore['nct_id'])
+        ctgov = Trial.find_by(system_id: oncore['nct_id'])
       end
       if ctgov.nil?  
-        trial = StudyFinder::Trial.find_or_initialize_by(system_id: @id)
+        trial = Trial.find_or_initialize_by(system_id: @id)
 
         trial.system_id = @id
 

--- a/lib/tasks/add_dates_to_trials.rake
+++ b/lib/tasks/add_dates_to_trials.rake
@@ -8,8 +8,8 @@ namespace :studyfinder do
 
   task add_dates_to_trials: :environment do |t, args|
     
-    parser_id = StudyFinder::Parser.find_by({ klass: 'Parsers::Ctgov'}).id
-    trials = StudyFinder::Trial.all
+    parser_id = Parser.find_by({ klass: 'Parsers::Ctgov'}).id
+    trials = Trial.all
     
     trials.each_with_index do |trial, index|
       p = Parsers::Ctgov.new(trial.system_id, parser_id)

--- a/lib/tasks/correspondance.rake
+++ b/lib/tasks/correspondance.rake
@@ -2,7 +2,7 @@ namespace :studyfinder do
   namespace :coorespondance do
     task generate_pis: :environment do |t, args|
 
-      results = StudyFinder::Trial.find_by_sql("
+      results = Trial.find_by_sql("
         select x.system_id, x.email, max(x.name) as name
         from (
         select system_id, contact_email as email, contact_last_name as name

--- a/lib/tasks/ctgov.rake
+++ b/lib/tasks/ctgov.rake
@@ -20,7 +20,7 @@ namespace :studyfinder do
       connector.process(true)
 
       puts "Reindexing all trials into elasticsearch"
-      StudyFinder::Trial.import force: true
+      Trial.import force: true
     end
 
     task refresh_all: :environment do |t, args|
@@ -31,7 +31,7 @@ namespace :studyfinder do
       connector.process(true)
 
       puts "Reindexing all trials into elasticsearch"
-      StudyFinder::Trial.import force: true
+      Trial.import force: true
     end
 
     # ==============================================================================================
@@ -49,7 +49,7 @@ namespace :studyfinder do
       connector.process(true)
 
       puts "Reindexing all trials into elasticsearch"
-      StudyFinder::Trial.import force: true
+      Trial.import force: true
     end
 
   end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,7 +1,7 @@
 namespace :studyfinder do
   namespace :trials do
     task reindex: :environment do |t, args|
-      StudyFinder::Trial.import force: true
+      Trial.import force: true
     end
   end
 end

--- a/lib/tasks/fix_age_ranges.rake
+++ b/lib/tasks/fix_age_ranges.rake
@@ -1,7 +1,7 @@
 namespace :studyfinder do
   task fix_ages: :environment do |t, args|
   
-    trials = StudyFinder::Trial.all
+    trials = Trial.all
 
     # Minimum Age
     trials.each do |trial|
@@ -54,7 +54,7 @@ namespace :studyfinder do
     end
 
     # Re-Index with the new fields.
-    StudyFinder::Trial.import force: true
+    Trial.import force: true
 
   end
 end

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Admin::GroupsController, :type => :controller do
 
   describe "GET #edit" do
     it "responds to an edit request" do
-      group = StudyFinder::Group.create({ group_name: 'Test' })
+      group = Group.create({ group_name: 'Test' })
       get :edit, params: { id: group.id }
       expect( assigns(:group) ).to eq(group)
       expect(response).to be_success
@@ -37,8 +37,8 @@ RSpec.describe Admin::GroupsController, :type => :controller do
 
   describe "PUT #update" do
     before :each do
-      @group = StudyFinder::Group.create({ group_name: 'Test' })
-      @condition = StudyFinder::Condition.create({ condition: 'Test Condition' })
+      @group = Group.create({ group_name: 'Test' })
+      @condition = Condition.create({ condition: 'Test Condition' })
     end
 
     it "successfully changes group's attributes" do

--- a/spec/controllers/researchers_controller_spec.rb
+++ b/spec/controllers/researchers_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ResearchersController, :type => :controller do
         contact_override_last_name: contact_override_last_name
       }
       
-      put :update, params: { id: trial.system_id, study_finder_trial: study_finder_trial, secret_key: @system_info.secret_key }
+      put :update, params: { id: trial.system_id, trial: study_finder_trial, secret_key: @system_info.secret_key }
       
       expect( assigns(:trial).simple_description ).to eq(simple_description)
       expect( assigns(:trial).contact_override ).to eq(contact_override)

--- a/spec/controllers/researchers_controller_spec.rb
+++ b/spec/controllers/researchers_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ResearchersController, :type => :controller do
       role: 'researcher'
     })
 
-    @system_info = StudyFinder::SystemInfo.create({
+    @system_info = SystemInfo.create({
       initials: 'UMN',
       school_name: 'University of Minnesota',
       system_name: 'Study Finder',
@@ -55,7 +55,7 @@ RSpec.describe ResearchersController, :type => :controller do
 
   describe "GET #edit" do
     it "responds to an edit request" do
-      trial = StudyFinder::Trial.create({ brief_title: 'Testing a title', system_id: 'NCT000001' })
+      trial = Trial.create({ brief_title: 'Testing a title', system_id: 'NCT000001' })
 
       get :edit, params: { id: trial.system_id }
       
@@ -67,7 +67,7 @@ RSpec.describe ResearchersController, :type => :controller do
 
   describe "PUT #update" do
     it "trial with override information" do
-      trial = StudyFinder::Trial.create({ brief_title: 'Testing a title', system_id: 'NCT000001' })
+      trial = Trial.create({ brief_title: 'Testing a title', system_id: 'NCT000001' })
 
       simple_description = 'Testing adding a simple_description'
       contact_override = 'jim@aol.com'
@@ -93,7 +93,7 @@ RSpec.describe ResearchersController, :type => :controller do
     end
 
     it "fails when a secret_key is not provided" do
-      trial = StudyFinder::Trial.create({ brief_title: 'Testing a title', system_id: 'NCT000001' })
+      trial = Trial.create({ brief_title: 'Testing a title', system_id: 'NCT000001' })
 
       simple_description = 'Testing adding a simple_description'
       contact_override = 'jim@aol.com'
@@ -114,7 +114,7 @@ RSpec.describe ResearchersController, :type => :controller do
     end
 
     it "fails when an invalid secret_key is added" do
-      trial = StudyFinder::Trial.create({ brief_title: 'Testing a title', system_id: 'NCT000001' })
+      trial = Trial.create({ brief_title: 'Testing a title', system_id: 'NCT000001' })
 
       simple_description = 'Testing adding a simple_description'
       contact_override = 'jim@aol.com'
@@ -137,8 +137,8 @@ RSpec.describe ResearchersController, :type => :controller do
 
   # describe "PUT #update" do
   #   before :each do
-  #     @group = StudyFinder::Group.create({ group_name: 'Test' })
-  #     @condition = StudyFinder::Condition.create({ condition: 'Test Condition' })
+  #     @group = Group.create({ group_name: 'Test' })
+  #     @condition = Condition.create({ condition: 'Test Condition' })
   #   end
 
   #   it "successfully changes group's attributes" do

--- a/spec/mailers/study_mailer_spec.rb
+++ b/spec/mailers/study_mailer_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 describe StudyMailer do
   describe 'contact_team' do
-    trial = StudyFinder::Trial.create({ 
+    trial = Trial.create({ 
       system_id: 'NCT00002668',
       brief_title: 'PATIENT SKILLS FOR CANCER PAIN CONTROL IN PATIENTS WITH METASTATIC BREAST OR PROSTATE CANCER',
       overall_status: 'Recruiting',
       healthy_volunteers: 'No'
     })
 
-    system_info = StudyFinder::SystemInfo.create({
+    system_info = SystemInfo.create({
       initials: 'UMN',
       school_name: 'University of Minnesota',
       system_name: 'Study Finder',

--- a/spec/parsers/ctgov_spec.rb
+++ b/spec/parsers/ctgov_spec.rb
@@ -18,7 +18,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.visible).to eq(true)
     end
 
@@ -33,7 +33,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.visible).to eq(false)
     end 
 
@@ -48,7 +48,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.visible).to eq(true)
 
       p2 = Parsers::Ctgov.new( 'NCT01678638', 1)
@@ -60,7 +60,7 @@ describe Parsers::Ctgov do
       ")
       p2.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.visible).to eq(false)
     end
 
@@ -75,7 +75,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.visible).to eq(false)
 
       p2 = Parsers::Ctgov.new( 'NCT01678638', 1)
@@ -87,7 +87,7 @@ describe Parsers::Ctgov do
       ")
       p2.process(true)
 
-      trial2 = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial2 = Trial.find_by(system_id: 'NCT01678638')
       expect(trial2.visible).to eq(true)
     end
     
@@ -110,7 +110,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.minimum_age).to eq(nil)
       expect(trial.maximum_age).to eq('0.71')
     end
@@ -134,7 +134,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.minimum_age).to eq('0.1')
       expect(trial.min_age_unit).to eq('37 Days')
       expect(trial.maximum_age).to eq('2')
@@ -160,7 +160,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.minimum_age).to eq('1.08')
       expect(trial.min_age_unit).to eq('13 Months')
       expect(trial.maximum_age).to eq('25.0')
@@ -187,7 +187,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.conditions.first.condition).to eq('Test Condition')
     end
 
@@ -214,7 +214,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.conditions.size).to eq(4)
       expect(trial.conditions.first.condition).to eq('Test Condition 1')
       expect(trial.conditions.last.condition).to eq('Test Condition 4')
@@ -234,7 +234,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.interventions).to eq('Intervention Type: Intervention Name')
     end
 
@@ -260,7 +260,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       interventions = trial.interventions.split("; ")
       expect(interventions.size).to eq(3)
       expect(interventions.first).to eq('Intervention Type 1: Intervention Name 1')
@@ -279,7 +279,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.keywords).to eq("Test Keyword")
     end
 
@@ -298,7 +298,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       keywords = trial.keywords.split("; ")
       expect(keywords.size).to eq(5)
       expect(keywords.first).to eq("Test Keyword 1")
@@ -319,7 +319,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.mesh_terms).to eq("Conditional: Test Conditional Mesh Term")
     end
 
@@ -338,7 +338,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       mesh_term = trial.mesh_terms.split("; ")
       expect(mesh_term.size).to eq(3)
       expect(mesh_term.first).to eq("Conditional: Test Conditional Mesh Term 1")
@@ -359,7 +359,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       expect(trial.mesh_terms).to eq("Intervention: Test Intervention Mesh Term")
     end
 
@@ -378,7 +378,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       mesh_term = trial.mesh_terms.split("; ")
       expect(mesh_term.size).to eq(3)
       expect(mesh_term.first).to eq("Intervention: Test Intervention Mesh Term 1")
@@ -407,7 +407,7 @@ describe Parsers::Ctgov do
       ")
       p.process(true)
 
-      trial = StudyFinder::Trial.find_by(system_id: 'NCT01678638')
+      trial = Trial.find_by(system_id: 'NCT01678638')
       mesh_term = trial.mesh_terms.split("; ")
       expect(mesh_term.size).to eq(6)
       expect(mesh_term.first).to eq("Conditional: Test Conditional Mesh Term 1")

--- a/spec/views/search/embed.html.haml_spec.rb
+++ b/spec/views/search/embed.html.haml_spec.rb
@@ -22,7 +22,7 @@ describe "search/embed" do
 
   it "changes not sure button to specific group/category if passed in as params[:group]" do
 
-    assign(:category, StudyFinder::Group.create!({ group_name: 'Heart Health' }) )
+    assign(:category, Group.create!({ group_name: 'Heart Health' }) )
 
     allow(view).to receive(:params).and_return({action: 'embed', group: 'Heart%20Health' })
 


### PR DESCRIPTION
Removing the StudyFinder base model inheritance from models. This eliminates the cumbersome and unnecessary prefixes. Each model already explicitly states the table name. It also eliminates the need to specify routes in forms as we're now using default routing, ex: 
`...simple_form_for(@user, :url => admin_users_path, :method => :post)...`
can now become
`...simple_form_for [:admin, @user]...`

