### PR TITLE
Category (group) toggle configuration

### DIFF
--- a/app/controllers/admin/system_controller.rb
+++ b/app/controllers/admin/system_controller.rb
@@ -42,7 +42,8 @@ class Admin::SystemController < ApplicationController
         :display_all_locations,
         :researcher_description,
         :secret_key,
-        :display_keywords
+        :display_keywords,
+        :display_groups_page
       )
     end
 end

--- a/app/views/admin/system/edit.html.erb
+++ b/app/views/admin/system/edit.html.erb
@@ -52,6 +52,12 @@
 
     <%= f.input :researcher_description, as: :text, input_html: { rows: 5 } %>
 
+    <label>Display Categories Page</label>
+    <small>
+      <i>(Show categories upon viewing the "Search for a Study" page)</i>
+    </small>
+    <%= f.input :display_groups_page, as: :select, label: false, include_blank: false %>
+
     <hr/>
     <h4> Analytics/Tracking Options</h4>
     <label>Google analytics tracking ID</label>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -8,7 +8,11 @@
     <div class="row">
       <ul class="nav navbar-nav pull-right">
         <li><a href="<%= root_path %>" <% if params[:controller] == 'home' %>class="active"<% end %>>Home</a></li>
-        <li><a href="<%= categories_path %>" <% if params[:controller] == 'categories' %>class="active"<% end %>>Search for a Study</a></li>
+        <% if @system_info.display_groups_page %>
+          <li><a href="<%= categories_path %>" <% if ['categories','studies'].include? params[:controller] %>class="active"<% end %>>Search for a Study</a></li>
+        <% else %>
+          <li><a href="<%= studies_path %>" <% if ['categories','studies'].include? params[:controller] %>class="active"<% end %>>Search for a Study</a></li>
+        <% end %>
         <li><a href="<%= researchers_path %>" <% if params[:controller] == 'researchers' %>class="active"<% end %> class="nav-for-researchers">For Researchers</a></li>
         <li><a href="<%= contact_index_path %>" <% if params[:controller] == 'contact' %>class="active"<% end %>>Contact Us</a></li>
         <% if is_admin? %>
@@ -28,5 +32,4 @@
       </ul>
     </div>
   </div>
-
 </div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -32,6 +32,8 @@
   <%= hidden_field 'search', 'category', value: @category.id unless @category.nil? %>
   <div class="search-controls">
     <%= submit_tag 'Search', class: 'btn btn-lg btn-school btn-search' %>
-    <a class="btn btn-primary btn-lg btn-search" href="<%=(@category.nil? ? categories_path : studies_path({ search: { category: @category.id } }) )%>" target="(params[:action] == 'embed' ? '_blank' : nil)">Browse by category</a>
+    <% if @system_info.try(:display_groups_page) == true %>
+      <a class="btn btn-primary btn-lg btn-search" href="<%=(@category.nil? ? categories_path : studies_path({ search: { category: @category.id } }) )%>" target="(params[:action] == 'embed' ? '_blank' : nil)">Browse by category</a>
+    <% end %>
   </div>
 <% end %>

--- a/db/migrate/20200622195327_add_category_config_to_system_infos.rb
+++ b/db/migrate/20200622195327_add_category_config_to_system_infos.rb
@@ -1,0 +1,5 @@
+class AddCategoryConfigToSystemInfos < ActiveRecord::Migration[5.2]
+  def change
+    add_column :study_finder_system_infos, :display_groups_page, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_17_194422) do
+ActiveRecord::Schema.define(version: 2020_06_22_195327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 2019_12_17_194422) do
     t.text "researcher_description"
     t.boolean "captcha", default: false, null: false
     t.boolean "display_keywords", default: true
+    t.boolean "display_groups_page", default: true, null: false
   end
 
   create_table "study_finder_trial_conditions", id: :serial, force: :cascade do |t|

--- a/spec/controllers/admin/system_controller_spec.rb
+++ b/spec/controllers/admin/system_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Admin::SystemController, :type => :controller do
+
+  before {
+    session.update({
+      email: 'kadrm002@umn.edu',
+      internet_id: 'kadrm002',
+      first_name: 'Jason',
+      last_name: 'Kadrmas',
+      role: 'admin'
+    })
+  }
+
+  describe "GET #index" do
+    it "redirects to edit page" do
+      get :index
+      expect( redirect_to @system )
+    end
+  end
+
+  describe "GET #edit" do
+    it "responds to an edit request" do
+      system = SystemInfo.create({ initials: 'UMN', school_name: 'University of Minnesota', system_name: 'StudyFinder', secret_key: 'test', default_email: 'noreply@umn.edu' })
+      
+      get :edit, params: { id: system.id }
+      expect( assigns(:system) ).to eq(system)
+      expect(response).to be_success
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "PUT #update" do
+    before :each do
+      @system = SystemInfo.create({ initials: 'UMN', school_name: 'University of Minnesota', system_name: 'StudyFinder', secret_key: 'test', default_email: 'noreply@umn.edu' })
+    end
+
+    it "successfully updates attributes" do
+      put :update, params: { id: @system, system_info: {school_name: 'Testing...', display_groups_page: false } }
+      @system.reload
+      
+      expect( @system.school_name ).to eq('Testing...')
+      expect( @system.display_groups_page ).to eq(false)
+      expect( redirect_to @system )
+    end
+  end
+end

--- a/spec/views/search/embed.html.erb_spec.rb
+++ b/spec/views/search/embed.html.erb_spec.rb
@@ -8,7 +8,6 @@ describe "search/embed" do
     render
 
     expect(rendered).not_to match /target=\"_blank\"/
-    expect(rendered).to match /categories/
   end
 
   it "displays a search form in an embed format" do
@@ -17,18 +16,26 @@ describe "search/embed" do
     render
 
     expect(rendered).to match /target=\"_blank\"/
-    expect(rendered).to match /categories/
   end
 
   it "changes not sure button to specific group/category if passed in as params[:group]" do
-
+    @system_info = SystemInfo.create({ initials: 'UMN', school_name: 'University of Minnesota', system_name: 'StudyFinder', secret_key: 'test', default_email: 'noreply@umn.edu', display_groups_page: true})
     assign(:category, Group.create!({ group_name: 'Heart Health' }) )
-
     allow(view).to receive(:params).and_return({action: 'embed', group: 'Heart%20Health' })
 
     render
     
     expect(rendered).to match /search_category/
     expect(rendered).to match /search%5Bcategory%5D=/
+  end
+
+  it "does not render the 'by category' logic if groups are suppressed" do
+    @system_info = SystemInfo.create({ initials: 'UMN', school_name: 'University of Minnesota', system_name: 'StudyFinder', secret_key: 'test', default_email: 'noreply@umn.edu', display_groups_page: false})
+    allow(view).to receive(:params).and_return({action: 'embed'})
+
+    render
+    
+    expect(rendered).not_to match /search_category/
+    expect(rendered).not_to match /search%5Bcategory%5D=/
   end
 end


### PR DESCRIPTION
Creates a mechanism for administrators to configure whether or not Categories are displayed within the site. It creates a boolean in the system_infos table to key off of. If true (default value) the site will operate as it has historically, however if false the "browse by categories" button will be hidden from the search form and clicking the "search for a study" nav item will bring users directly to the study results page.