### PR TITLE
Relabeling gender as sex as sex is a biological term.

### DIFF
--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -109,7 +109,7 @@ module StudiesHelper
         gender
       end
     else
-      'No gender available'
+      'No info available'
     end
   end
 

--- a/app/views/shared/_refine_search.html.erb
+++ b/app/views/shared/_refine_search.html.erb
@@ -12,7 +12,7 @@
           <option value='0' <% if healthy_voulunteers == '0' %>selected<%end%> >No</option>
           <option value=''>No Preference</option>
         </select>
-        <label class="gender-label">Gender</label>
+        <label class="gender-label">Sex</label>
         <% gender = params[:search]['gender'] if !params[:search].nil? and !params[:search]['gender'].nil? %>
         <select id="gender" name="search[gender]" class="form-control">
           <option value=''>Any</option>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="row">
     <div class="col-md-6">
-      <label for='gender'>Gender</label>
+      <label for='gender'>Sex</label>
       <select id="gender" name="search[gender]" class="form-control">
         <option value=''>Any</option>
         <option value='Female'>Female</option>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -107,7 +107,7 @@
       <% end %>
 
       <div class="field important nomargin">
-        <label class="single">Gender:</label>
+        <label class="single">Sex:</label>
         <strong>
           <%= eligibility_display(t.gender) %>
         </strong>


### PR DESCRIPTION
Relabeling "Gender" to "Sex" as 'sex' is a biological/clinical term and 'gender' generally refers to an identity. This change is only front-facing. The back-end still references gender because the database column and ctgov attribute are both 'gender'.