### PR TITLE
Allow multiple elasticsearch hosts in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ encryption: :simple_tls
 departmental_cn: 'USERNAME'
 departmental_pw: 'PASSWORD'
 theme: 'umn'
-es_host: 'elastic.umn.edu'
+es_host: 'elastic.umn.edu' # or multiple hosts separated by commas: 'elastic1.example.com, elastic2.example.com'
 
 ```
 

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,5 +1,4 @@
-if Rails.env == 'local'
-  Elasticsearch::Model.client = Elasticsearch::Client.new log: true
-else
-  Elasticsearch::Model.client = Elasticsearch::Client.new(log: true, host: ENV['es_host'])
-end
+Elasticsearch::Model.client = Elasticsearch::Client.new(
+  log: true,
+  host: ENV["es_host"].to_s.gsub(" ", "").split(",")
+)


### PR DESCRIPTION
This allows mutiple elasticsearch hosts to be configured if a cluster is being used. Existing single-node configurations will continue to work with no changes.

The local environment check was removed because it unnecessarily defines Elasticsearch::Client's default configuration. If no hosts are configured, Elasticsearch::Client defaults to localhost:9200.