### PR TITLE
Add Configurable Study Show Page

### DIFF
--- a/app/assets/stylesheets/pages/studies.css.scss
+++ b/app/assets/stylesheets/pages/studies.css.scss
@@ -80,6 +80,17 @@
     background: $highlight_color;
   }
 
+  h4{
+    a {
+      text-decoration: underline;
+      //font-weight: bold;
+      color: $school_main_color;
+    }
+    a:hover {
+      background-color: $school_secondary_color;
+    }
+  }
+  
   hr {
     margin: 30px 0;
   }

--- a/app/controllers/admin/system_controller.rb
+++ b/app/controllers/admin/system_controller.rb
@@ -43,7 +43,8 @@ class Admin::SystemController < ApplicationController
         :researcher_description,
         :secret_key,
         :display_keywords,
-        :display_groups_page
+        :display_groups_page,
+        :display_study_show_page
       )
     end
 end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -4,30 +4,30 @@ class StudiesController < ApplicationController
   respond_to :html, :json
   
   def index
-    search_parameters = params[:search].deep_dup if !params[:search].nil?
+    @search_parameters = params[:search].deep_dup if !params[:search].nil?
 
     if !params[:search].nil? and !params[:search][:category].nil?
       @group = Group.find(params[:search][:category])
       
       if @group.conditions_empty?
-        search_parameters = search_parameters.except!(:category)
+        @search_parameters = @search_parameters.except!(:category)
       end
     end
 
     if params[:search].nil? or params[:search][:q].blank?
       # Show all trials that are visible, there were no search terms entered.
-      search_parameters = {} if search_parameters.nil?
-      @trials = Trial.match_all(search_parameters).page(params[:page]).results
+      @search_parameters = {} if @search_parameters.nil?
+      @trials = Trial.match_all(@search_parameters).page(params[:page]).results
     else
       # There is actually a search term here.
       # phrase_search = Trial.phrase_search(params[:search]).page(params[:page]).results
       # unless phrase_search.total == 0
       #   @trials = phrase_search
       # else
-        params[:search][:q] = replace_words(search_parameters[:q])
-        search_parameters[:q] = params[:search][:q]
+        params[:search][:q] = replace_words(@search_parameters[:q])
+        @search_parameters[:q] = params[:search][:q]
 
-        @trials = Trial.match_all_search(search_parameters).page(params[:page]).results
+        @trials = Trial.match_all_search(@search_parameters).page(params[:page]).results
         # if match_all.total == 0
         #   @trials = Trial.match_synonyms(params[:search]).page(params[:page]).results
         # else
@@ -35,11 +35,20 @@ class StudiesController < ApplicationController
         # end  
       # end
       if @trials.total == 0
-        @suggestions = Trial.suggestions(search_parameters[:q])
+        @suggestions = Trial.suggestions(@search_parameters[:q])
       end
     end
 
     respond_with(@trials)
+  end
+
+  def show
+    unless @system_info.display_study_show_page
+      redirect_to studies_path, flash: { success: 'Apologies, This page is not available.' } and return
+    end
+
+    @study = Trial.find(params[:id])
+    params[:search].nil? ? @search_params = {} : @search_params = JSON.parse(params[:search])
   end
 
   def typeahead

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -46,9 +46,7 @@ class StudiesController < ApplicationController
     unless @system_info.display_study_show_page
       redirect_to studies_path, flash: { success: 'Apologies, This page is not available.' } and return
     end
-
     @study = Trial.find(params[:id])
-    params[:search].nil? ? @search_params = {} : @search_params = JSON.parse(params[:search])
   end
 
   def typeahead

--- a/app/views/admin/system/edit.html.erb
+++ b/app/views/admin/system/edit.html.erb
@@ -58,6 +58,12 @@
     </small>
     <%= f.input :display_groups_page, as: :select, label: false, include_blank: false %>
 
+    <label>Display Study Show Page</label>
+    <small>
+      <i>(Create a landing page for each study)</i>
+    </small>
+    <%= f.input :display_study_show_page, as: :select, label: false, include_blank: false %>
+
     <hr/>
     <h4> Analytics/Tracking Options</h4>
     <label>Google analytics tracking ID</label>

--- a/app/views/studies/_modals.html.erb
+++ b/app/views/studies/_modals.html.erb
@@ -1,0 +1,77 @@
+<div id="email-me-modal" name="email-me-modal" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4><i class="fa fa-envelope"></i> Email this study information to me</h4>
+      </div>
+      <div class="modal-body">
+        <form id="email-me-form" onsubmit="return false;">
+          <label>Study Title</label>
+          <p class="study-title"></p>
+          <div class="form-group">
+            <label>Email address (*)</label>
+            <input class="form-control email" type="text"></input>
+          </div>
+          <div class="form-group">
+            <label>Additional Notes</label>
+            <textarea class="form-control notes"></textarea>
+          </div>
+          <% if @system_info.captcha %>
+            <div class="form-group">
+              <div id="myself-captcha" name="myself-captcha"></div>
+            </div>
+          <% end %>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-default" data-dismiss='modal' onclick="track('send', 'event', 'email_me_close', 'close')">Close</button>
+        <button class="btn btn-school" id="email-me-modal-submit" name="email-me-modal-submit" data-trial-id="" onclick="track('send', 'event', 'email_me_submit', 'submit')">Send</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="contact-study-team-modal" name="ontact-study-team-modal" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4><i class="fa fa-envelope"></i> Contact the study team</h4>
+      </div>
+      <div class="modal-body">
+        <form id="contact-study-team-form" onsubmit="return false;">
+          <label>Study Email</label>
+          <p class="study-email"></p>
+          <div class="form-group">
+            <label>Email address (*)</label>
+            <input class="form-control email" type="text"></input>
+          </div>
+          <div class="form-group">
+            <label>Name (*)</label>
+            <input class="form-control name" type="text"></input>
+          </div>
+          <div class="form-group">
+            <label>Phone</label>
+            <input class="form-control phone" type="text"></input>
+          </div>
+          <div class="form-group">
+            <label>Notes</label>
+            <textarea class="form-control notes"></textarea>
+          </div>
+          <% if @system_info.captcha %>
+            <div class="form-group">
+              <div id="study-team-captcha" name="study-team-captcha"></div>
+            </div>
+          <% end %>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-default" data-dismiss='modal' onclick="track('send', 'event', 'email_study_team_close', 'close')">Close</button>
+        <button class="btn btn-school" id="contact-study-team-modal-submit" name="contact-study-team-modal-submit" data-trial-id="" onclick="track('send', 'event', 'email_study_team_submit', 'submit')">Send</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% if @system_info.captcha %>
+  <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit"></script>
+<% end %>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -70,7 +70,13 @@
 
   <% @trials.each_with_index do |t, i| %>
     <div class="study">
-      <h4><%= highlight(t, 'display_title') %></h4>
+      <h4>
+        <% if @system_info.display_study_show_page %>
+          <%= link_to highlight(t, 'display_title'), study_path(id: t.id, search: @search_parameters.deep_dup.to_json) %>
+        <% else %>
+          <%= highlight(t, 'display_title') %>
+        <% end %>
+      </h4>
       <% unless t.simple_description.blank? %>
         <div class="field important">
           <strong>
@@ -204,6 +210,10 @@
       <% end %>
 
       <div class="trial-cta-options">
+        <% if @system_info.display_study_show_page %>
+          <%= link_to "<i class='fa fa-bookmark'></i> View Study".html_safe, study_path(id: t.id, search: @search_parameters.to_json), class: 'btn btn-school'%>
+        <% end %>
+
         <div class="btn btn-school btn-email-me" data-toggle='modal' data-target='#email-me-modal' data-title="<%=t.display_title%>" data-trial-id="<%=t.id%>" onclick="track('send', 'event', 'email_me', 'open', '<%= t.system_id %>')"><i class="fa fa-envelope"></i> Email this study information to me</div>
         
         <% unless c.empty? %>
@@ -253,82 +263,6 @@
   <% end %>
   <hr/>
   <%= will_paginate @trials, renderer: BootstrapPagination::Rails %>
-</div> 
-
-<div id="email-me-modal" name="email-me-modal" class="modal fade">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h4><i class="fa fa-envelope"></i> Email this study information to me</h4>
-      </div>
-      <div class="modal-body">
-        <form id="email-me-form" onsubmit="return false;">
-          <label>Study Title</label>
-          <p class="study-title"></p>
-          <div class="form-group">
-            <label>Email address (*)</label>
-            <input class="form-control email" type="text"></input>
-          </div>
-          <div class="form-group">
-            <label>Additional Notes</label>
-            <textarea class="form-control notes"></textarea>
-          </div>
-          <% if @system_info.captcha %>
-            <div class="form-group">
-              <div id="myself-captcha" name="myself-captcha"></div>
-            </div>
-          <% end %>
-        </form>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-default" data-dismiss='modal' onclick="track('send', 'event', 'email_me_close', 'close')">Close</button>
-        <button class="btn btn-school" id="email-me-modal-submit" name="email-me-modal-submit" data-trial-id="" onclick="track('send', 'event', 'email_me_submit', 'submit')">Send</button>
-      </div>
-    </div>
-  </div>
 </div>
 
-<div id="contact-study-team-modal" name="ontact-study-team-modal" class="modal fade">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h4><i class="fa fa-envelope"></i> Contact the study team</h4>
-      </div>
-      <div class="modal-body">
-        <form id="contact-study-team-form" onsubmit="return false;">
-          <label>Study Email</label>
-          <p class="study-email"></p>
-          <div class="form-group">
-            <label>Email address (*)</label>
-            <input class="form-control email" type="text"></input>
-          </div>
-          <div class="form-group">
-            <label>Name (*)</label>
-            <input class="form-control name" type="text"></input>
-          </div>
-          <div class="form-group">
-            <label>Phone</label>
-            <input class="form-control phone" type="text"></input>
-          </div>
-          <div class="form-group">
-            <label>Notes</label>
-            <textarea class="form-control notes"></textarea>
-          </div>
-          <% if @system_info.captcha %>
-            <div class="form-group">
-              <div id="study-team-captcha" name="study-team-captcha"></div>
-            </div>
-          <% end %>
-        </form>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-default" data-dismiss='modal' onclick="track('send', 'event', 'email_study_team_close', 'close')">Close</button>
-        <button class="btn btn-school" id="contact-study-team-modal-submit" name="contact-study-team-modal-submit" data-trial-id="" onclick="track('send', 'event', 'email_study_team_submit', 'submit')">Send</button>
-      </div>
-    </div>
-  </div>
-</div>
-
-<% if @system_info.captcha %>
-  <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit"></script>
-<% end %>
+<%= render 'modals' %>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -72,7 +72,7 @@
     <div class="study">
       <h4>
         <% if @system_info.display_study_show_page %>
-          <%= link_to highlight(t, 'display_title'), study_path(id: t.id, search: @search_parameters.deep_dup.to_json) %>
+          <%= link_to highlight(t, 'display_title'), study_path(id: t.id, search: @search_parameters.to_json) %>
         <% else %>
           <%= highlight(t, 'display_title') %>
         <% end %>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -72,7 +72,7 @@
     <div class="study">
       <h4>
         <% if @system_info.display_study_show_page %>
-          <%= link_to highlight(t, 'display_title'), study_path(id: t.id, search: @search_parameters.to_json) %>
+          <%= link_to highlight(t, 'display_title'), study_path(id: t.id) %>
         <% else %>
           <%= highlight(t, 'display_title') %>
         <% end %>
@@ -211,7 +211,7 @@
 
       <div class="trial-cta-options">
         <% if @system_info.display_study_show_page %>
-          <%= link_to "<i class='fa fa-bookmark'></i> View Study".html_safe, study_path(id: t.id, search: @search_parameters.to_json), class: 'btn btn-school'%>
+          <%= link_to "<i class='fa fa-bookmark'></i> View Study".html_safe, study_path(id: t.id), class: 'btn btn-school'%>
         <% end %>
 
         <div class="btn btn-school btn-email-me" data-toggle='modal' data-target='#email-me-modal' data-title="<%=t.display_title%>" data-trial-id="<%=t.id%>" onclick="track('send', 'event', 'email_me', 'open', '<%= t.system_id %>')"><i class="fa fa-envelope"></i> Email this study information to me</div>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -1,0 +1,78 @@
+<% c = determine_contacts(@study) %>
+<div>
+  <div class="clearfix">
+    <div class="pull-left">
+      <h3><%= @study.brief_title %></h3>
+      <div class="well">
+        <label>Status:</label>  <span class="<%= ['Recruiting','Enrolling by invitation'].include?(@study.overall_status) ? 'label label-success' : 'label label-info' %>"><%= @study.try(:overall_status) %></span><br>
+        <label>System ID:</label> <span><%= @study.system_id %></span><br>
+        <label>Sex:</label> <span><%= eligibility_display(@study.gender) %></span><br>
+        <label>Age:</label> <span><%= (@study.respond_to?(:min_age_unit) and @study.respond_to?(:max_age_unit)) ? age_display_units(@study.min_age_unit, @study.max_age_unit) : age_display(@study.min_age, @study.max_age) %></span><br>
+        <div class="healthy-message" data-toggle='popover' data-title='Healthy Volunteer' data-content='A person who does not have the condition or disease being studied.' data-placement='top'>
+          <% if @study.healthy_volunteers == true %>
+            <i class="fa fa-check-circle"></i>This study is also accepting healthy volunteers <i class="fa fa-question-circle"></i>
+          <% else %>
+            <i class="fa fa-exclamation-triangle"></i>This study is NOT accepting healthy volunteers <i class="fa fa-question-circle"></i>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="button-holder">
+  <% unless @study.recruitment_url.blank? %>
+    <a class="btn btn-school btn-recruitment" href="<%=@study.recruitment_url%>" target="_blank"><i class="fa fa-users" target="_blank"></i> See if you are a good fit for this study</a>
+  <% end %>
+  <div class="btn btn-school btn-email-me" data-toggle='modal' data-target='#email-me-modal' data-title="<%=@study.display_title%>" data-trial-id="<%=@study.id%>" onclick="track('send', 'event', 'email_me', 'open', '<%= @study.system_id %>')"><i class="fa fa-envelope"></i> Share via email</div>
+  <% unless c.empty? %>
+    <div class="btn btn-school btn-email-study-team" data-toggle='modal' data-target='#contact-study-team-modal' data-email="<%=c.first[:email]%>" data-trial-id="<%=@study.id%>" onclick="track('send', 'event', 'email_study_team', 'open', '#{@study.system_id}')"><i class="fa fa-envelope"></i> Contact the study team</div>
+  <% end %>
+  <a class="btn btn-school btn-more-info" href="https://www.clinicaltrials.gov/ct2/show/study/<%= @study.system_id %>" onclick="track('send', 'event', 'ctgov', 'click', '<%= @study.system_id %>')" target="_blank"><i class="fa fa-info-circle"></i> See more information</a>
+</div>
+<br>
+
+<ul class="nav nav-tabs" id="myTab" role="tablist">
+  <li class="nav-item active"><a class="nav-link active" id="conditions-tab" data-toggle="tab" href="#conditions" role="tab" aria-controls="conditions" aria-selected="true">Conditions & Interventions</a></li>
+  <li class="nav-item"><a class="nav-link" id="eligibility-tab" data-toggle="tab" href="#eligibility" role="tab" aria-controls="eligibility" aria-selected="false">Eligibility Criteria</a></li>
+  <li class="nav-item"><a class="nav-link" id="details-tab" data-toggle="tab" href="#details" role="tab" aria-controls="details" aria-selected="false">Additional Details</a></li>
+</ul>
+<br>
+<div class="tab-content" id="myTabContent">
+  <div class="tab-pane active" id="conditions" role="tabpanel" aria-labelledby="conditions-tab">
+    <div class="field nomargin">
+      <label>Interventions:</label>
+      <p><%= @study.interventions.gsub(/;/,',').html_safe unless @study.interventions.nil? %></p>
+    </div>
+    <div class="field nomargin">
+      <label>Conditions:</label>
+      <p><%= @study.conditions_map.gsub(/;/,',').html_safe unless @study.conditions_map.nil? %></p>
+    </div>
+    <div class="field nomargin">
+      <label>Keywords:</label>
+      <p><%= @study.keywords.gsub(/;/,',').html_safe unless @study.keywords.nil? %></p>
+    </div>
+  </div>
+  <div class="tab-pane fade" id="eligibility" role="tabpanel" aria-labelledby="eligibility-tab">
+    <% unless @study.eligibility_criteria.nil? %>
+      <%= @study.eligibility_criteria.gsub(' - ', '<br class="eligibility-line-break"> &bull;').gsub('Inclusion Criteria:', '<div class="eligibility-header"><strong>Inclusion Criteria:</strong></div>').gsub('Exclusion Criteria:', '<hr><div class="eligibility-header"><strong>Exclusion Criteria:</strong></div>').gsub('Healthy volunteers', '<div class="eligibility-header"><strong>Healthy volunteers</strong></div>').html_safe %>
+    <% end %>
+  </div>
+  <div class="tab-pane fade" id="details" role="tabpanel" aria-labelledby="details-tab">
+    <% unless @study.simple_description.blank? %>
+      <div><label>Description:</label>  <%= @study.simple_description %></div>
+    <% end %>
+    <div><label>Contact(s):</label> <%= contacts_display(c) %></div>
+    <div><label>Principal Investigator:</label> <%= @study.try(:pi_name) %></div>
+    <div><label>Principal Investigator ID:</label> <%= @study.try(:pi_id) %></div>
+    <div><label>Phase:</label> <%= @study.try(:phase) %></div>
+    <div><label>IRB Number:</label> <%= @study.try(:irb_number) %></div>
+  </div>
+</div>
+<br>
+
+<% unless @search_params.nil? %>
+  <%= link_to 'Back to Results', studies_path(search: @search_params), class: 'btn btn-school' %>
+<% end %>
+
+<%= render 'modals' %>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -71,8 +71,6 @@
 </div>
 <br>
 
-<% unless @search_params.nil? %>
-  <%= link_to 'Back to Results', studies_path(search: @search_params), class: 'btn btn-school' %>
-<% end %>
+<%= link_to 'Back', :back, class: 'btn btn-school' %>
 
 <%= render 'modals' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   post 'researchers/trials/search', controller: 'researchers', action: 'search_results', as: :search_trial_results_researchers
   resources :sessions, only: ['new', 'create']
   delete 'sessions/destroy', controller: 'sessions', action: 'destroy', as: 'session' # manually creating this route to exclude requiring an id in the destroy route
-  resources :studies, only: ['index']
+  resources :studies, only: ['index', 'show']
   get 'studies/typeahead', controller: 'studies', action: 'typeahead'
   post 'studies/contact_team', controller: 'studies', action: 'contact_team'
   post 'studies/email_me', controller: 'studies', action: 'email_me'

--- a/db/migrate/20200710133712_add_study_show_config_to_system_infos.rb
+++ b/db/migrate/20200710133712_add_study_show_config_to_system_infos.rb
@@ -1,0 +1,5 @@
+class AddStudyShowConfigToSystemInfos < ActiveRecord::Migration[5.2]
+  def change
+    add_column :study_finder_system_infos, :display_study_show_page, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_22_195327) do
+ActiveRecord::Schema.define(version: 2020_07_10_133712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 2020_06_22_195327) do
     t.boolean "captcha", default: false, null: false
     t.boolean "display_keywords", default: true
     t.boolean "display_groups_page", default: true, null: false
+    t.boolean "display_study_show_page", default: false, null: false
   end
 
   create_table "study_finder_trial_conditions", id: :serial, force: :cascade do |t|

--- a/spec/controllers/studies_controller_spec.rb
+++ b/spec/controllers/studies_controller_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe StudiesController, :type => :controller do
+
+  describe "GET #index" do
+    it "responds successfully with an HTTP 200 status code" do
+      get :index
+      expect(response).to be_success
+      expect(response).to have_http_status(200)
+    end
+
+    it "renders the index template" do
+      get :index
+      expect(response).to render_template("index")
+    end
+  end
+
+  describe "GET #show" do
+    
+    before {
+      @study = Trial.create({
+        system_id: 'NCT001test',
+        brief_title: 'test',
+        official_title: 'test'
+      })
+    }
+
+    it "redirects study show page if disabled" do
+      SystemInfo.destroy_all
+      @system_info = SystemInfo.create({ initials: 'UMN', school_name: 'University of Minnesota', system_name: 'StudyFinder', secret_key: 'test', default_email: 'noreply@umn.edu', display_study_show_page: false})
+      
+      get :show, params: { id: @study.id }
+
+      expect(response).to redirect_to(studies_url)
+      expect(flash[:success]).to eq('Apologies, This page is not available.')
+    end
+
+    it "successfully renders study show page if enabled" do
+      SystemInfo.destroy_all
+      @system_info = SystemInfo.create({ initials: 'UMN', school_name: 'University of Minnesota', system_name: 'StudyFinder', secret_key: 'test', default_email: 'noreply@umn.edu', display_study_show_page: true})
+      
+      get :show, params: { id: @study.id }
+
+      expect(response).to be_success
+      expect(response).to have_http_status(200)
+      expect(response).to render_template("show")
+    end
+  end
+
+end

--- a/spec/views/search/embed.html.erb_spec.rb
+++ b/spec/views/search/embed.html.erb_spec.rb
@@ -19,6 +19,7 @@ describe "search/embed" do
   end
 
   it "changes not sure button to specific group/category if passed in as params[:group]" do
+    SystemInfo.destroy_all
     @system_info = SystemInfo.create({ initials: 'UMN', school_name: 'University of Minnesota', system_name: 'StudyFinder', secret_key: 'test', default_email: 'noreply@umn.edu', display_groups_page: true})
     assign(:category, Group.create!({ group_name: 'Heart Health' }) )
     allow(view).to receive(:params).and_return({action: 'embed', group: 'Heart%20Health' })
@@ -30,6 +31,7 @@ describe "search/embed" do
   end
 
   it "does not render the 'by category' logic if groups are suppressed" do
+    SystemInfo.destroy_all
     @system_info = SystemInfo.create({ initials: 'UMN', school_name: 'University of Minnesota', system_name: 'StudyFinder', secret_key: 'test', default_email: 'noreply@umn.edu', display_groups_page: false})
     allow(view).to receive(:params).and_return({action: 'embed'})
 


### PR DESCRIPTION
This PR adds a configurable study show page to StudyFinder. The default action is to disable the show page to preserve historic functionality. Administrators may enable the show page from the System Administration interface.