### PR TITLE
Study Attribute Toggles

### DIFF
--- a/app/assets/stylesheets/pages/admin.css.scss
+++ b/app/assets/stylesheets/pages/admin.css.scss
@@ -57,4 +57,8 @@
   .collection_check_boxes {
     font-weight: normal;
   }
+
+  .highlight-col {
+    background-color: whitesmoke;
+  }
 }

--- a/app/assets/stylesheets/pages/studies.css.scss
+++ b/app/assets/stylesheets/pages/studies.css.scss
@@ -157,7 +157,6 @@
     position: relative;
 
     label {
-      display: block;
       color: #404d5b;
     }
 
@@ -208,12 +207,6 @@
     margin: 5px;
   }
 
-  .healthy-message {
-    cursor: pointer;
-    max-width: 400px;
-    display: inline-block;
-  }
-
   .eligibility-line-break {
     display: block;
     content: " ";
@@ -238,4 +231,14 @@
 
 .eligibility-criteria {
   margin-bottom: 10px;
+}
+
+.healthy-message {
+  cursor: pointer;
+  max-width: 400px;
+  display: inline-block;
+}
+
+.strong {
+  font-weight: bold;
 }

--- a/app/controllers/admin/system_controller.rb
+++ b/app/controllers/admin/system_controller.rb
@@ -44,7 +44,8 @@ class Admin::SystemController < ApplicationController
         :secret_key,
         :display_keywords,
         :display_groups_page,
-        :display_study_show_page
+        :display_study_show_page,
+        trial_attribute_settings_attributes: [:id, :attribute_label, :display_label_on_list, :display_attribute_on_list, :display_attribute_if_null_on_list, :display_label_on_show, :display_attribute_on_show, :display_attribute_if_null_on_show]
       )
     end
 end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -5,7 +5,8 @@ class StudiesController < ApplicationController
   
   def index
     @search_parameters = params[:search].deep_dup if !params[:search].nil?
-
+    @attribute_settings = TrialAttributeSetting.where(system_info_id: @system_info.id)
+    
     if !params[:search].nil? and !params[:search][:category].nil?
       @group = Group.find(params[:search][:category])
       
@@ -47,6 +48,7 @@ class StudiesController < ApplicationController
       redirect_to studies_path, flash: { success: 'Apologies, This page is not available.' } and return
     end
     @study = Trial.find(params[:id])
+    @attribute_settings = TrialAttributeSetting.where(system_info_id: @system_info.id)
   end
 
   def typeahead

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -113,6 +113,23 @@ module StudiesHelper
     end
   end
 
+  def render_healthy_volunteers(study)
+    rendered = '<div class="healthy-message" data-toggle="popover" data-title="Healthy Volunteer" data-content="A person who does not have the condition or disease being studied." data-placement="top">'
+            
+    if study.healthy_volunteers == true
+      rendered = rendered + '<i class="fa fa-check-circle"></i>This study is also accepting healthy volunteers <i class="fa fa-question-circle"></i>'
+    else
+      rendered = rendered + '<i class="fa fa-exclamation-triangle"></i>This study is NOT accepting healthy volunteers <i class="fa fa-question-circle"></i>'
+    end
+    rendered = rendered + '</div>'
+
+    return rendered.html_safe
+  end
+
+  def render_age_display(study)
+     return (study.respond_to?(:min_age_unit) and study.respond_to?(:max_age_unit)) ? age_display_units(study.min_age_unit, study.max_age_unit) : age_display(study.min_age, study.max_age)
+  end
+
   def age_display_units(min_age_unit, max_age_unit)
     if min_age_unit == 'N/A' and max_age_unit != 'N/A'
       return "up to #{max_age_unit} old"
@@ -184,5 +201,26 @@ module StudiesHelper
     end
 
     return site_name
+  end
+
+  def render_attribute(settings, key, page, attribute, new_line = false)
+    setting = settings.select{|x|x.attribute_key == key}.first
+    rendered = ''
+    return rendered if setting.nil?
+
+    open_tag = (new_line == false ? '<span>' : '<p>')
+    close_tag = (new_line == false ? '</span>' : '</p>')
+
+    if page == 'show' && setting.display_attribute_on_show && !(setting.display_attribute_if_null_on_show == false && (attribute.nil? || attribute.blank?))
+      #configured to show up on the page unless attribute is nil
+      rendered = rendered + '<label>' + setting.attribute_label + '</label> ' if setting.display_label_on_show
+      rendered = rendered + open_tag + attribute.to_s + close_tag
+    elsif page == 'list' && setting.display_attribute_on_list && !(setting.display_attribute_if_null_on_list == false && (attribute.nil? || attribute.blank?))
+      rendered = rendered + '<label>' + setting.attribute_label + '</label> ' if setting.display_label_on_list
+      rendered = rendered + open_tag + attribute.to_s + close_tag
+    end
+    rendered = '<div class="nomargin" data-attribute-name=' + setting.attribute_key + '>' + rendered + '</div>' unless rendered == ''
+
+    return rendered.html_safe
   end
 end

--- a/app/models/system_info.rb
+++ b/app/models/system_info.rb
@@ -1,6 +1,9 @@
 class SystemInfo < ApplicationRecord
   self.table_name = 'study_finder_system_infos'
 
+  has_many :trial_attribute_settings#, optional: true
+  accepts_nested_attributes_for :trial_attribute_settings, allow_destroy: false, reject_if: :all_blank
+
   validates_presence_of :secret_key, :default_email, :initials, :school_name
   # validates_format_of :secret_key, with: /[^0-9a-z]/i
 

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -194,6 +194,7 @@ class Trial < ApplicationRecord
     self.as_json(
       only: [
         :simple_description,
+        :overall_status,
         :eligibility_criteria,
         :system_id,
         :gender,

--- a/app/models/trial_attribute_setting.rb
+++ b/app/models/trial_attribute_setting.rb
@@ -1,0 +1,4 @@
+class TrialAttributeSetting < ApplicationRecord
+  belongs_to :system_infos
+  validates :attribute_name, presence: true
+end

--- a/app/views/admin/system/edit.html.erb
+++ b/app/views/admin/system/edit.html.erb
@@ -9,70 +9,135 @@
   <hr/>
 
   <%= simple_form_for @system, url: admin_system_path do |f| %>
-    <h4> Basic Information</h4>
-    <%= f.input :initials %>
-    <%= f.input :school_name %>
-    <%= f.input :system_header %>
-    <%= f.input :system_description, as: :text, input_html: { rows: 5 } %>
-    <%= f.input :default_url %>
-    <%= f.input :default_email %>
-    <%= f.input :secret_key, hint: 'Secret key will be required by researchers to add or update trials.' %>
+    
+    <ul class="nav nav-tabs" id="myTab" role="tablist">
+      <li class="nav-item active"><a class="nav-link active" id="basic-tab" data-toggle="tab" href="#basic" role="tab" aria-controls="basic" aria-selected="true">Basic Information</a></li>
+      <li class="nav-item"><a class="nav-link" id="override-tab" data-toggle="tab" href="#override" role="tab" aria-controls="override" aria-selected="false">System Override Options</a></li>
+      <li class="nav-item"><a class="nav-link" id="trial-display-tab" data-toggle="tab" href="#trial-display" role="tab" aria-controls="trial-display" aria-selected="false">Study Attribute Display Options</a></li>
+      <li class="nav-item"><a class="nav-link" id="tracking-tab" data-toggle="tab" href="#tracking" role="tab" aria-controls="tracking" aria-selected="false">Analytics/Tracking Options</a></li>
+    </ul>
+    <br>
+    <div class="tab-content" id="myTabContent">
+      <div class="tab-pane active" id="basic" role="tabpanel" aria-labelledby="basic-tab">
+        <h4> Basic Information</h4>
+        <%= f.input :initials %>
+        <%= f.input :school_name %>
+        <%= f.input :system_header %>
+        <%= f.input :system_description, as: :text, input_html: { rows: 5 } %>
+        <%= f.input :default_url %>
+        <%= f.input :default_email %>
+        <%= f.input :secret_key, hint: 'Secret key will be required by researchers to add or update trials.' %>
 
-    <label>Add Captcha to email forms</label>
-    <small>
-      <i>(Turning on captcha will require a recaptcha key.  Refer to the readme instructions on github for more details.)</i>
-    </small>
-    <%= f.input :captcha, as: :select, label: false %>
+        <label>Add Captcha to email forms</label>
+        <small>
+          <i>(Turning on captcha will require a recaptcha key.  Refer to the readme instructions on github for more details.)</i>
+        </small>
+        <%= f.input :captcha, as: :select, label: false %>
+      </div>
+      <div class="tab-pane fade" id="override" role="tabpanel" aria-labelledby="override-tab">
+        <h4> System Override Options</h4>
+        <label>Search Term</label>
+        <small>
+          <i>(Search term is the term that will be used to pull clinical trials from ClinicalTrials.gov)</i>
+        </small>
+        <%= f.input :search_term, label: false %>
 
-    <hr/>
-    <h4> System Override Options</h4>
-    <label>Search Term</label>
-    <small>
-      <i>(Search term is the term that will be used to pull clinical trials from ClinicalTrials.gov)</i>
-    </small>
-    <%= f.input :search_term, label: false %>
+        <label>Contact email suffix</label>
+        <small>
+          <i>(If populated, the system will find and display only contacts with this email pattern. On a trial located at multiple sites, the system will attempt to provide a @umn.edu email as the contact.)</i>
+        </small>
+        <%= f.input :contact_email_suffix, label: false %>
 
-    <label>Contact email suffix</label>
-    <small>
-      <i>(If populated, the system will find and display only contacts with this email pattern. On a trial located at multiple sites, the system will attempt to provide a @umn.edu email as the contact.)</i>
-    </small>
-    <%= f.input :contact_email_suffix, label: false %>
+        <label>Display Locations</label>
+        <small>
+          <i>(When a trial is located at multiple sites "display locations" determines if those other sites be listed within StudyFinder)</i>
+        </small>
+        <%= f.input :display_all_locations, as: :select, label: false %>
 
-    <label>Display Locations</label>
-    <small>
-      <i>(When a trial is located at multiple sites "display locations" determines if those other sites be listed within StudyFinder)</i>
-    </small>
-    <%= f.input :display_all_locations, as: :select, label: false %>
+        <label>Display Keywords</label>
+        <small>
+          <i>(Show a trial's keywords in the search results)</i>
+        </small>
+        <%= f.input :display_keywords, as: :select, label: false %>
 
-    <label>Display Keywords</label>
-    <small>
-      <i>(Show a trial's keywords in the search results)</i>
-    </small>
-    <%= f.input :display_keywords, as: :select, label: false %>
+        <%= f.input :researcher_description, as: :text, input_html: { rows: 5 } %>
 
-    <%= f.input :researcher_description, as: :text, input_html: { rows: 5 } %>
+        <label>Display Categories Page</label>
+        <small>
+          <i>(Show categories upon viewing the "Search for a Study" page)</i>
+        </small>
+        <%= f.input :display_groups_page, as: :select, label: false, include_blank: false %>
 
-    <label>Display Categories Page</label>
-    <small>
-      <i>(Show categories upon viewing the "Search for a Study" page)</i>
-    </small>
-    <%= f.input :display_groups_page, as: :select, label: false, include_blank: false %>
+        <label>Display Study Show Page</label>
+        <small>
+          <i>(Create a landing page for each study)</i>
+        </small>
+        <%= f.input :display_study_show_page, as: :select, label: false, include_blank: false %>
+      </div>
+      <div class="tab-pane fade" id="trial-display" role="tabpanel" aria-labelledby="trial-display-tab">
+        <h4> Study Attribute Display Options</h4>
 
-    <label>Display Study Show Page</label>
-    <small>
-      <i>(Create a landing page for each study)</i>
-    </small>
-    <%= f.input :display_study_show_page, as: :select, label: false, include_blank: false %>
-
-    <hr/>
-    <h4> Analytics/Tracking Options</h4>
-    <label>Google analytics tracking ID</label>
-    <%= f.input :google_analytics_id, label: false %>
-    <%= f.input :research_match_campaign %>
-    <div class="form-group string optional">
-      <label class="string optional control-label" for="campaign_source"}>Campaign Source</label>
-      <input class="string optional form-control" id="campaign_source"></input>
+        <table class="table">
+          <tr>
+            <th colspan="2"></th>
+            <th colspan="3" class="highlight-col text-center">List Page Display Settings</th>
+            <th colspan="3" class="text-center">Show Page Display Settings</th>
+          </tr>
+          <tr>
+            <th>Attribute</th>
+            <th>Label</th>
+            <th class="highlight-col">Display Attribute</th>
+            <th class="highlight-col">Display If Blank</th>
+            <th class="highlight-col">Display Label</th>
+            <th>Display Attribute</th>
+            <th>Display If Blank</th>
+            <th>Display Label</th>
+          </tr>
+          <% @system.trial_attribute_settings.order(:attribute_name).each do |t| %>
+            <tr>
+              <input type="hidden" value="<%=t.id%>" name="system_info[trial_attribute_settings_attributes][<%=t.id%>][id]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_id" ></input>
+              <td><%= t.attribute_name %></td>
+              <td><input type="text" value="<%= t.attribute_label %>" name="system_info[trial_attribute_settings_attributes][<%=t.id%>][attribute_label]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_attribute_label"></td>
+              <td class="highlight-col">
+                <input type="hidden" value="0" name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_attribute_on_list]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_display_attribute_on_list">
+                <input type="checkbox" value="1" <% if t.display_attribute_on_list %>checked="checked"<% end %> name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_attribute_on_list]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_display_attribute_on_list">
+              </td>
+              <td class="highlight-col">
+                <input type="hidden" value="0" name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_attribute_if_null_on_list]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>display_attribute_if_null_on_list">
+                <input type="checkbox" value="1" <% if t.display_attribute_if_null_on_list %>checked="checked"<% end %> name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_attribute_if_null_on_list]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_display_attribute_if_null_on_list">
+              </td>
+              <td class="highlight-col">
+                <input type="hidden" value="0" name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_label_on_list]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>display_label_on_list">
+                <input type="checkbox" value="1" <% if t.display_label_on_list %>checked="checked"<% end %> name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_label_on_list]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_display_label_on_list">
+              </td>
+              <td>
+                <input type="hidden" value="0" name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_attribute_on_show]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_display_attribute_on_show">
+                <input type="checkbox" value="1" <% if t.display_attribute_on_show %>checked="checked"<% end %> name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_attribute_on_show]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_display_attribute_on_show">
+              </td>
+              <td>
+                <input type="hidden" value="0" name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_attribute_if_null_on_show]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>display_attribute_if_null_on_show">
+                <input type="checkbox" value="1" <% if t.display_attribute_if_null_on_show %>checked="checked"<% end %> name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_attribute_if_null_on_show]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_display_attribute_if_null_on_show">
+              </td>
+              <td>
+                <input type="hidden" value="0" name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_label_on_show]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>display_label_on_show">
+                <input type="checkbox" value="1" <% if t.display_label_on_show %>checked="checked"<% end %> name="system_info[trial_attribute_settings_attributes][<%=t.id%>][display_label_on_show]" id="system_info_trial_attribute_settings_attributes_<%=t.id%>_display_label_on_show">
+              </td>
+            </tr>
+          <% end %>
+        </table>
+      </div>
+      <div class="tab-pane fade" id="tracking" role="tabpanel" aria-labelledby="tracking-tab">
+        <h4> Analytics/Tracking Options</h4>
+        <label>Google analytics tracking ID</label>
+        <%= f.input :google_analytics_id, label: false %>
+        <%= f.input :research_match_campaign %>
+        <div class="form-group string optional">
+          <label class="string optional control-label" for="campaign_source"}>Campaign Source</label>
+          <input class="string optional form-control" id="campaign_source"></input>
+        </div>
+      </div>
     </div>
+    <br>
     <%= f.submit 'Update System Information', class: 'btn btn-school' %>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <link href="https://fonts.googleapis.com/css?family=Prompt:400,700" type="text/css" rel="stylesheet">
 
   <%= stylesheet_link_tag    'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
   <meta name=viewport content="width=device-width, initial-scale=1">
   <meta name=apple-mobile-web-app-capable content=yes>
@@ -32,7 +33,6 @@
       <span id="utm-campaign"></span>
     </footer>
   </div>
-  <%= javascript_include_tag 'application' %>
   <%= render 'shared/analytics' %>
 </body>
 </html>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -77,86 +77,19 @@
           <%= highlight(t, 'display_title') %>
         <% end %>
       </h4>
-      <% unless t.simple_description.blank? %>
-        <div class="field important">
-          <strong>
-            <label>Description:</label>
-            <%= highlight(t, 'simple_description') %>
-          </strong>
-        </div>
-      <% end %>
-
-      <div class="field important">
-        <strong>
-          <label>Contact(s):</label>
-          <% c = determine_contacts(t) %>
-          <%= contacts_display(c) %>
-        </strong>
-      </div>
-
-      <% if t.respond_to?(:pi_name) %>
-        <div class="field important nomargin">
-          <label class="single">Principal Investigator:</label>
-          <strong>
-            <%= t.pi_name %>
-          </strong>
-        </div>
-      <% end %>
-
-      <% if t.respond_to?(:pi_id) %>
-        <div class="field important nomargin">
-          <label class="single">Principal Investigator ID:</label>
-          <strong>
-            <%= t.pi_id %>
-          </strong>
-        </div>
-      <% end %>
-
-      <div class="field important nomargin">
-        <label class="single">Sex:</label>
-        <strong>
-          <%= eligibility_display(t.gender) %>
-        </strong>
-      </div>
-
-      <div class="field important nomargin">
-        <label class="single">Age:</label>
-        <strong>
-          <%= (t.respond_to?(:min_age_unit) and t.respond_to?(:max_age_unit)) ? age_display_units(t.min_age_unit, t.max_age_unit) : age_display(t.min_age, t.max_age) %>
-        </strong>
-      </div>
-
-      <div class="field important nomargin">
-        <label class="single">Phase:</label>
-        <strong>
-          <%= t.phase %>
-        </strong>
-      </div>
       
-      <div class="field important nomargin">
-        <label class="single">Healthy Volunteers</label>
-        <strong>
-          <div class="healthy-message" data-toggle='popover' data-title='Healthy Volunteer' data-content='A person who does not have the condition or disease being studied.' data-placement='top'>
-            <% if t.healthy_volunteers == true %>
-              <i class="fa fa-check-circle"></i>This study is also accepting healthy volunteers <i class="fa fa-question-circle"></i>
-            <% else %>
-              <i class="fa fa-exclamation-triangle"></i>This study is NOT accepting healthy volunteers <i class="fa fa-question-circle"></i>
-            <% end %>
-          </div>
-        </strong>
-      </div>
-
-      <div class="field nomargin">
-        <label class="single">System ID:</label>
-        <%= t.system_id %>
-      </div>
-
-      <% unless t.irb_number.blank? %>
-        <div class="field nomargin">
-          <label class="single">IRB Number:</label>
-          <%= t.irb_number %>
-        </div>
-      <% end %>
+      <% c = determine_contacts(t) %>
+      <%= render_attribute(@attribute_settings, 'simple_description', 'list', t.simple_description, true) %>
+      <%= render_attribute(@attribute_settings, 'overall_status', 'list', t.overall_status) %>
+      <%= render_attribute(@attribute_settings, 'contacts', 'list', contacts_display(c), true) %>
+      <%= render_attribute(@attribute_settings, 'principal_investigator', 'list', t.pi_name) %>
+      <%= render_attribute(@attribute_settings, 'principal_investigator_id', 'list', t.pi_id) %>
+      <%= render_attribute(@attribute_settings, 'gender', 'list', eligibility_display(t.gender)) %>
+      <%= render_attribute(@attribute_settings, 'age', 'list', render_age_display(t)) %>
+      <%= render_attribute(@attribute_settings, 'phase', 'list', t.phase) %>
+      <%= render_attribute(@attribute_settings, 'healthy_volunteers', 'list', render_healthy_volunteers(t)) %>
+      <%= render_attribute(@attribute_settings, 'system_id', 'list', t.system_id) %>
+      <%= render_attribute(@attribute_settings, 'irb_number', 'list', t.irb_number) %>
 
       <% unless t.eligibility_criteria.nil? %>
         <div class="field important eligibility-buttons">
@@ -164,50 +97,15 @@
           <div class="btn btn-xs btn-school-inverse btn-hide-full-eligibility hide"><i class="fa fa-close"></i> Hide eligibility criteria</div>
         </div>
         <div class="eligibility-criteria hide">
-          <%= highlight(t, 'eligibility_criteria').gsub(' - ', '<br class="eligibility-line-break"> &bull;').gsub('Inclusion Criteria:', '<div class="eligibility-header"><strong>Inclusion Criteria:</strong></div>').gsub('Exclusion Criteria:', '<div class="eligibility-header"><strong>Exclusion Criteria:</strong></div>').gsub('Healthy volunteers', '<div class="eligibility-header"><strong>Healthy volunteers</strong></div>').html_safe %>
+          <%= render_attribute(@attribute_settings, 'eligibility_criteria', 'list', t.eligibility_criteria.gsub(' - ', '<br class="eligibility-line-break"> &bull;').gsub('Inclusion Criteria:', '<div class="eligibility-header"><strong>Inclusion Criteria:</strong></div>').gsub('Exclusion Criteria:', '<hr><div class="eligibility-header"><strong>Exclusion Criteria:</strong></div>').gsub('Healthy volunteers', '<div class="eligibility-header"><strong>Healthy volunteers</strong></div>')) %>
         </div>
       <% end %>
       
-      <% unless t.interventions.nil? %>
-        <div class="field nomargin">
-          <label class="single">Interventions:</label>
-          <div class="concept-list">
-            <%= highlight(t, 'interventions').gsub(';', ',').html_safe %>
-          </div>
-        </div>
-      <% end %>
-
-      <% unless t.conditions_map.nil? %>
-        <div class="field nomargin">
-          <label class="single">Conditions:</label>
-          <div class="concept-list">
-            <%= highlight(t, 'conditions_map').gsub(';', ',').html_safe %>
-          </div>
-        </div>
-      <% end %>
-
-      <% if @system_info.display_keywords? && !t.keywords.blank? %>
-        <div class="field nomargin">
-          <label class="single">Keywords:</label>
-          <div class="concept-list">
-            <%= highlight(t, 'keywords').gsub(';', ',').html_safe %>
-          </div>
-        </div>
-      <% end %>
-
-      <% if t.respond_to?(:sites) && !t.sites.blank? %>
-        <div class="field nomargin">
-          <label class="single">Sites:</label>
-          <%= t.sites.map {|x| site(x) }.join('; ') %>
-        </div>
-      <% end %>
-
-      <% if t.respond_to?(:disease_sites) && !t.disease_sites.blank? %>
-        <div class="field nomargin">
-          <label class="single">Disease Sites:</label>
-          <%= t.disease_sites.map {|x| x.disease_site_name }.join('; ') %>
-        </div>
-      <% end %>
+      <%= render_attribute(@attribute_settings, 'interventions', 'list', t.interventions.to_s.gsub(/;/,',').html_safe) %>
+      <%= render_attribute(@attribute_settings, 'conditions', 'list', t.conditions_map.to_s.gsub(/;/,',').html_safe) %>
+      <%= render_attribute(@attribute_settings, 'keywords', 'list', t.keywords.to_s.gsub(/;/,',').html_safe) %>
+      <%= render_attribute(@attribute_settings, 'sites', 'list', t.sites.map{|x| site(x) }.join('; ')) %>
+      <%= render_attribute(@attribute_settings, 'disease_sites', 'list', t.disease_sites.map{|x| x.disease_site_name }.join('; ')) %>
 
       <div class="trial-cta-options">
         <% if @system_info.display_study_show_page %>
@@ -266,3 +164,16 @@
 </div>
 
 <%= render 'modals' %>
+
+<script>
+ $(document).ready(function() {
+  $('div[data-attribute-name="overall_status"').addClass("strong important");
+  $('div[data-attribute-name="contacts"').addClass("strong important");
+  $('div[data-attribute-name="principal_investigator"').addClass("strong important");
+  $('div[data-attribute-name="principal_investigator_id"').addClass("strong important");
+  $('div[data-attribute-name="gender"').addClass("strong important");
+  $('div[data-attribute-name="age"').addClass("strong important");
+  $('div[data-attribute-name="phase"').addClass("strong important");
+  $('div[data-attribute-name="healthy_volunteers"').addClass("strong important");
+ });
+</script>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -1,21 +1,14 @@
 <% c = determine_contacts(@study) %>
-<div>
-  <div class="clearfix">
-    <div class="pull-left">
-      <h3><%= @study.brief_title %></h3>
-      <div class="well">
-        <label>Status:</label>  <span class="<%= ['Recruiting','Enrolling by invitation'].include?(@study.overall_status) ? 'label label-success' : 'label label-info' %>"><%= @study.try(:overall_status) %></span><br>
-        <label>System ID:</label> <span><%= @study.system_id %></span><br>
-        <label>Sex:</label> <span><%= eligibility_display(@study.gender) %></span><br>
-        <label>Age:</label> <span><%= (@study.respond_to?(:min_age_unit) and @study.respond_to?(:max_age_unit)) ? age_display_units(@study.min_age_unit, @study.max_age_unit) : age_display(@study.min_age, @study.max_age) %></span><br>
-        <div class="healthy-message" data-toggle='popover' data-title='Healthy Volunteer' data-content='A person who does not have the condition or disease being studied.' data-placement='top'>
-          <% if @study.healthy_volunteers == true %>
-            <i class="fa fa-check-circle"></i>This study is also accepting healthy volunteers <i class="fa fa-question-circle"></i>
-          <% else %>
-            <i class="fa fa-exclamation-triangle"></i>This study is NOT accepting healthy volunteers <i class="fa fa-question-circle"></i>
-          <% end %>
-        </div>
-      </div>
+
+<div class="clearfix">
+  <div class="pull-left">
+    <h3><%= @study.brief_title %></h3>
+    <div class="well">
+      <%= render_attribute(@attribute_settings, 'overall_status', 'show', @study.overall_status) %>
+      <%= render_attribute(@attribute_settings, 'system_id', 'show', @study.system_id) %>
+      <%= render_attribute(@attribute_settings, 'gender', 'show', eligibility_display(@study.gender)) %>
+      <%= render_attribute(@attribute_settings, 'age', 'show', render_age_display(@study)) %>
+      <%= render_attribute(@attribute_settings, 'healthy_volunteers', 'show', render_healthy_volunteers(@study)) %>
     </div>
   </div>
 </div>
@@ -40,33 +33,22 @@
 <br>
 <div class="tab-content" id="myTabContent">
   <div class="tab-pane active" id="conditions" role="tabpanel" aria-labelledby="conditions-tab">
-    <div class="field nomargin">
-      <label>Interventions:</label>
-      <p><%= @study.interventions.gsub(/;/,',').html_safe unless @study.interventions.nil? %></p>
-    </div>
-    <div class="field nomargin">
-      <label>Conditions:</label>
-      <p><%= @study.conditions_map.gsub(/;/,',').html_safe unless @study.conditions_map.nil? %></p>
-    </div>
-    <div class="field nomargin">
-      <label>Keywords:</label>
-      <p><%= @study.keywords.gsub(/;/,',').html_safe unless @study.keywords.nil? %></p>
-    </div>
+    <%= render_attribute(@attribute_settings, 'interventions', 'show', @study.interventions.to_s.gsub(/;/,',').html_safe, true) %>
+    <%= render_attribute(@attribute_settings, 'conditions', 'show', @study.conditions_map.to_s.gsub(/;/,',').html_safe, true) %>
+    <%= render_attribute(@attribute_settings, 'keywords', 'show', @study.keywords.to_s.gsub(/;/,',').html_safe, true) %>
+    <%= render_attribute(@attribute_settings, 'sites', 'show', @study.sites.map{|x| site(x) }.join('; '), true) %>
+    <%= render_attribute(@attribute_settings, 'disease_sites', 'show', @study.disease_sites.map{|x| x.disease_site_name }.join('; '), true) %>
   </div>
   <div class="tab-pane fade" id="eligibility" role="tabpanel" aria-labelledby="eligibility-tab">
-    <% unless @study.eligibility_criteria.nil? %>
-      <%= @study.eligibility_criteria.gsub(' - ', '<br class="eligibility-line-break"> &bull;').gsub('Inclusion Criteria:', '<div class="eligibility-header"><strong>Inclusion Criteria:</strong></div>').gsub('Exclusion Criteria:', '<hr><div class="eligibility-header"><strong>Exclusion Criteria:</strong></div>').gsub('Healthy volunteers', '<div class="eligibility-header"><strong>Healthy volunteers</strong></div>').html_safe %>
-    <% end %>
+    <%= render_attribute(@attribute_settings, 'eligibility_criteria', 'show', @study.eligibility_criteria.gsub(' - ', '<br class="eligibility-line-break"> &bull;').gsub('Inclusion Criteria:', '<div class="eligibility-header"><strong>Inclusion Criteria:</strong></div>').gsub('Exclusion Criteria:', '<hr><div class="eligibility-header"><strong>Exclusion Criteria:</strong></div>').gsub('Healthy volunteers', '<div class="eligibility-header"><strong>Healthy volunteers</strong></div>')) %>
   </div>
   <div class="tab-pane fade" id="details" role="tabpanel" aria-labelledby="details-tab">
-    <% unless @study.simple_description.blank? %>
-      <div><label>Description:</label>  <%= @study.simple_description %></div>
-    <% end %>
-    <div><label>Contact(s):</label> <%= contacts_display(c) %></div>
-    <div><label>Principal Investigator:</label> <%= @study.try(:pi_name) %></div>
-    <div><label>Principal Investigator ID:</label> <%= @study.try(:pi_id) %></div>
-    <div><label>Phase:</label> <%= @study.try(:phase) %></div>
-    <div><label>IRB Number:</label> <%= @study.try(:irb_number) %></div>
+    <%= render_attribute(@attribute_settings, 'simple_description', 'show', @study.simple_description) %>
+    <%= render_attribute(@attribute_settings, 'contacts', 'show', contacts_display(c)) %>
+    <%= render_attribute(@attribute_settings, 'principal_investigator', 'show', @study.pi_name) %>
+    <%= render_attribute(@attribute_settings, 'principal_investigator_id', 'show', @study.pi_id) %>
+    <%= render_attribute(@attribute_settings, 'phase', 'show', @study.phase) %>
+    <%= render_attribute(@attribute_settings, 'irb_number', 'show', @study.irb_number) %>
   </div>
 </div>
 <br>
@@ -74,3 +56,9 @@
 <%= link_to 'Back', :back, class: 'btn btn-school' %>
 
 <%= render 'modals' %>
+
+<script>
+ $(document).ready(function() {
+  $('div[data-attribute-name="overall_status"').find("span").addClass("<%= ['Recruiting','Enrolling by invitation'].include?(@study.overall_status) ? 'label label-success' : 'label label-info' %>");
+ });
+</script>

--- a/db/migrate/20200723212151_create_trial_attribute_settings.rb
+++ b/db/migrate/20200723212151_create_trial_attribute_settings.rb
@@ -1,0 +1,36 @@
+class CreateTrialAttributeSettings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :trial_attribute_settings do |t|
+      t.integer :system_info_id
+      t.string :attribute_name
+      t.string :attribute_key
+      t.string :attribute_label
+      t.boolean :display_label_on_list, default: true
+      t.boolean :display_attribute_on_list, default: true
+      t.boolean :display_attribute_if_null_on_list, default: true
+      t.boolean :display_label_on_show, default: true
+      t.boolean :display_attribute_on_show, default: true
+      t.boolean :display_attribute_if_null_on_show, default: true
+    end
+
+    #seed data 
+    system = SystemInfo.first
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Overall Status', attribute_key: 'overall_status', attribute_label: 'Status:', display_attribute_on_list: false)
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Simple Description', attribute_key: 'simple_description', attribute_label: 'Description:', display_attribute_if_null_on_list: false, display_attribute_if_null_on_show: false)
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Contacts', attribute_key: 'contacts', attribute_label: 'Contact(s):')
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Principal Investigator', attribute_key: 'principal_investigator:', attribute_label: 'Principal Investigator')
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Principal Investigator ID', attribute_key: 'principal_investigator_id:', attribute_label: 'Principal Investigator ID')
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Gender', attribute_key: 'gender', attribute_label: 'Sex:')
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Age', attribute_key: 'age', attribute_label: 'Age:')
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Phase', attribute_key: 'phase', attribute_label: 'Phase:')
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'IRB Number', attribute_key: 'irb_number', attribute_label: 'IRB Number:', display_attribute_if_null_on_list: false)
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Healthy Volunteers', attribute_key: 'healthy_volunteers', attribute_label: 'Healthy Volunteers:')
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'System ID', attribute_key: 'system_id', attribute_label: 'System ID:')
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Eligibility Criteria', attribute_key: 'eligibility_criteria', attribute_label: 'Eligibility Criteria:', display_label_on_show: false, display_label_on_list: false, display_attribute_if_null_on_list: false)
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Interventions', attribute_key: 'interventions', attribute_label: 'Interventions:', display_attribute_if_null_on_list: false, display_attribute_if_null_on_show: false)
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Conditions', attribute_key: 'conditions', attribute_label: 'Conditions:', display_attribute_if_null_on_list: false, display_attribute_if_null_on_show: false)
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Keywords', attribute_key: 'keywords', attribute_label: 'Keywords:', display_attribute_if_null_on_list: false, display_attribute_if_null_on_show: false)
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Sites', attribute_key: 'sites', attribute_label: 'Sites:', display_attribute_on_show: false, display_attribute_if_null_on_list: false, display_attribute_if_null_on_list: false)
+    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Disease Sites', attribute_key: 'disease_sites', attribute_label: 'Disease Sites:', display_attribute_on_show: false, display_attribute_if_null_on_list: false, display_attribute_if_null_on_list: false)
+  end
+end

--- a/db/migrate/20200723212151_create_trial_attribute_settings.rb
+++ b/db/migrate/20200723212151_create_trial_attribute_settings.rb
@@ -16,8 +16,10 @@ class CreateTrialAttributeSettings < ActiveRecord::Migration[5.2]
     #seed data
     up_only do
       system_info = SystemInfo.first
-      attributes = JSON.parse(IO.read(Rails.root.join("db/seeds/trial_attribute_settings.json")))
-      system_info.trial_attribute_settings.create(attributes)
+      if system_info
+        attributes = JSON.parse(IO.read(Rails.root.join("db/seeds/trial_attribute_settings.json")))
+        system_info.trial_attribute_settings.create(attributes)
+      end
     end
   end
 end

--- a/db/migrate/20200723212151_create_trial_attribute_settings.rb
+++ b/db/migrate/20200723212151_create_trial_attribute_settings.rb
@@ -13,24 +13,11 @@ class CreateTrialAttributeSettings < ActiveRecord::Migration[5.2]
       t.boolean :display_attribute_if_null_on_show, default: true
     end
 
-    #seed data 
-    system = SystemInfo.first
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Overall Status', attribute_key: 'overall_status', attribute_label: 'Status:', display_attribute_on_list: false)
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Simple Description', attribute_key: 'simple_description', attribute_label: 'Description:', display_attribute_if_null_on_list: false, display_attribute_if_null_on_show: false)
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Contacts', attribute_key: 'contacts', attribute_label: 'Contact(s):')
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Principal Investigator', attribute_key: 'principal_investigator:', attribute_label: 'Principal Investigator')
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Principal Investigator ID', attribute_key: 'principal_investigator_id:', attribute_label: 'Principal Investigator ID')
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Gender', attribute_key: 'gender', attribute_label: 'Sex:')
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Age', attribute_key: 'age', attribute_label: 'Age:')
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Phase', attribute_key: 'phase', attribute_label: 'Phase:')
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'IRB Number', attribute_key: 'irb_number', attribute_label: 'IRB Number:', display_attribute_if_null_on_list: false)
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Healthy Volunteers', attribute_key: 'healthy_volunteers', attribute_label: 'Healthy Volunteers:')
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'System ID', attribute_key: 'system_id', attribute_label: 'System ID:')
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Eligibility Criteria', attribute_key: 'eligibility_criteria', attribute_label: 'Eligibility Criteria:', display_label_on_show: false, display_label_on_list: false, display_attribute_if_null_on_list: false)
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Interventions', attribute_key: 'interventions', attribute_label: 'Interventions:', display_attribute_if_null_on_list: false, display_attribute_if_null_on_show: false)
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Conditions', attribute_key: 'conditions', attribute_label: 'Conditions:', display_attribute_if_null_on_list: false, display_attribute_if_null_on_show: false)
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Keywords', attribute_key: 'keywords', attribute_label: 'Keywords:', display_attribute_if_null_on_list: false, display_attribute_if_null_on_show: false)
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Sites', attribute_key: 'sites', attribute_label: 'Sites:', display_attribute_on_show: false, display_attribute_if_null_on_list: false, display_attribute_if_null_on_list: false)
-    TrialAttributeSetting.create(system_info_id: system.id, attribute_name: 'Disease Sites', attribute_key: 'disease_sites', attribute_label: 'Disease Sites:', display_attribute_on_show: false, display_attribute_if_null_on_list: false, display_attribute_if_null_on_list: false)
+    #seed data
+    up_only do
+      system_info = SystemInfo.first
+      attributes = JSON.parse(IO.read(Rails.root.join("db/seeds/trial_attribute_settings.json")))
+      system_info.trial_attribute_settings.create(attributes)
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_10_133712) do
+ActiveRecord::Schema.define(version: 2020_07_23_212151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -231,6 +231,19 @@ ActiveRecord::Schema.define(version: 2020_07_10_133712) do
     t.datetime "updated_at"
     t.index ["email"], name: "index_study_finder_users_on_email", unique: true
     t.index ["internet_id"], name: "index_study_finder_users_on_internet_id", unique: true
+  end
+
+  create_table "trial_attribute_settings", force: :cascade do |t|
+    t.integer "system_info_id"
+    t.string "attribute_name"
+    t.string "attribute_key"
+    t.string "attribute_label"
+    t.boolean "display_label_on_list", default: true
+    t.boolean "display_attribute_on_list", default: true
+    t.boolean "display_attribute_if_null_on_list", default: true
+    t.boolean "display_label_on_show", default: true
+    t.boolean "display_attribute_on_show", default: true
+    t.boolean "display_attribute_if_null_on_show", default: true
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -95,3 +95,11 @@ end
 # ============================================
 
 Rake::Task['studyfinder:ctgov:load'].invoke
+
+# ============================================
+# Trial attribute settings
+# ============================================
+attribute_setting_data = JSON.parse(IO.read(Rails.root.join("db/seeds/trial_attribute_settings.json")))
+system_info = SystemInfo.first
+system_info.trial_attribute_settings.delete_all
+system_info.trial_attribute_settings.create(attribute_setting_data)

--- a/db/seeds/trial_attribute_settings.json
+++ b/db/seeds/trial_attribute_settings.json
@@ -1,0 +1,19 @@
+[
+  { "attribute_name": "Overall Status", "attribute_key": "overall_status", "attribute_label": "Status:", "display_attribute_on_list": false  },
+  { "attribute_name": "Simple Description", "attribute_key": "simple_description", "attribute_label": "Description:", "display_attribute_if_null_on_list": false, "display_attribute_if_null_on_show": false  },
+  { "attribute_name": "Contacts", "attribute_key": "contacts", "attribute_label": "Contact(s },:" },
+  { "attribute_name": "Principal Investigator", "attribute_key": "principal_investigator:", "attribute_label": "Principal Investigator" },
+  { "attribute_name": "Principal Investigator ID", "attribute_key": "principal_investigator_id:", "attribute_label": "Principal Investigator ID" },
+  { "attribute_name": "Gender", "attribute_key": "gender", "attribute_label": "Sex:" },
+  { "attribute_name": "Age", "attribute_key": "age", "attribute_label": "Age:" },
+  { "attribute_name": "Phase", "attribute_key": "phase", "attribute_label": "Phase:" },
+  { "attribute_name": "IRB Number", "attribute_key": "irb_number", "attribute_label": "IRB Number:", "display_attribute_if_null_on_list": false },
+  { "attribute_name": "Healthy Volunteers", "attribute_key": "healthy_volunteers", "attribute_label": "Healthy Volunteers:" },
+  { "attribute_name": "System ID", "attribute_key": "system_id", "attribute_label": "System ID:" },
+  { "attribute_name": "Eligibility Criteria", "attribute_key": "eligibility_criteria", "attribute_label": "Eligibility Criteria:", "display_label_on_show": false, "display_label_on_list": false, "display_attribute_if_null_on_list": false },
+  { "attribute_name": "Interventions", "attribute_key": "interventions", "attribute_label": "Interventions:", "display_attribute_if_null_on_list": false, "display_attribute_if_null_on_show": false },
+  { "attribute_name": "Conditions", "attribute_key": "conditions", "attribute_label": "Conditions:", "display_attribute_if_null_on_list": false, "display_attribute_if_null_on_show": false },
+  { "attribute_name": "Keywords", "attribute_key": "keywords", "attribute_label": "Keywords:", "display_attribute_if_null_on_list": false, "display_attribute_if_null_on_show": false },
+  { "attribute_name": "Sites", "attribute_key": "sites", "attribute_label": "Sites:", "display_attribute_on_show": false, "display_attribute_if_null_on_list": false, "display_attribute_if_null_on_list": false },
+  { "attribute_name": "Disease Sites", "attribute_key": "disease_sites", "attribute_label": "Disease Sites:", "display_attribute_on_show": false, "display_attribute_if_null_on_list": false, "display_attribute_if_null_on_list": false }
+]


### PR DESCRIPTION
Adding attribute display options for study index/show pages; configurable through the system admin interface. Initial attribute configuration should mirror existing functionality. 

*Note: overall_status has been added to the study index page and  the Trial.rb 'as_indexed_json' method. As a result the site must be re-indexed.