### PR TITLE
Adding Contact URL to Trials

### DIFF
--- a/app/controllers/admin/trials_controller.rb
+++ b/app/controllers/admin/trials_controller.rb
@@ -119,7 +119,7 @@ class Admin::TrialsController < ApplicationController
       params.require(:trial).permit(
         :simple_description, :visible, 
         :featured, :recruiting, :contact_override, :cancer_yn,
-        :contact_override_first_name, :contact_override_last_name, :pi_name, :pi_id, :recruitment_url, 
+        :contact_override_first_name, :contact_override_last_name, :pi_name, :pi_id, :recruitment_url, :contact_url_override,
         :reviewed, :irb_number, site_ids: [], disease_site_ids: [])
     end
 

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -69,6 +69,22 @@ module StudiesHelper
     end
   end
 
+  def determine_contact_method(trial)
+    if !trial.contact_url_override.blank? || !trial.contact_url.blank?
+      return 'url'
+    else
+      return 'email'
+    end
+  end
+
+  def render_contact_url(trial)
+    unless trial.contact_url_override.blank?
+      return trial.contact_url_override
+    else
+      return trial.contact_url
+    end
+  end
+
   def default_email
     return [{
       email: @system_info.default_email

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -200,6 +200,8 @@ class Trial < ApplicationRecord
         :gender,
         :healthy_volunteers,
         :visible,
+        :contact_url,
+        :contact_url_override,
         :contact_override,
         :contact_override_first_name,
         :contact_override_last_name,

--- a/app/views/admin/trials/edit.html.erb
+++ b/app/views/admin/trials/edit.html.erb
@@ -47,6 +47,7 @@
       <%= f.input :contact_override %>
       <%= f.input :contact_override_first_name %>
       <%= f.input :contact_override_last_name %>
+      <%= f.input :contact_url_override, hint: 'If supplied, the "Contact the Study Team" button will redirect to the specified URL instead of opening the contact modal.' %>
       <%= f.input :recruitment_url %>
       <%= f.input :irb_number, label: 'IRB Number' %>
     <% end %>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -113,8 +113,13 @@
 
         <div class="btn btn-school btn-email-me" data-toggle='modal' data-target='#email-me-modal' data-title="<%=t.display_title%>" data-trial-id="<%=t.id%>" onclick="track('send', 'event', 'email_me', 'open', '<%= t.system_id %>')"><i class="fa fa-envelope"></i> Email this study information to me</div>
         
-        <% unless c.empty? %>
-          <div class="btn btn-school btn-email-study-team" data-toggle='modal' data-target='#contact-study-team-modal' data-email="<%=c.first[:email]%>" data-trial-id="<%=t.id%>" onclick="track('send', 'event', 'email_study_team', 'open', '#{t.system_id}')"><i class="fa fa-envelope"></i> Contact the study team</div>
+        <% contact_method = determine_contact_method(t) %>
+        <% if contact_method == 'url' %>
+          <a class="btn btn-school" href="<%= render_contact_url(t) %>"><i class="fa fa-envelope"></i> Contact the study team</a>
+        <% elsif contact_method == 'email' %>
+          <% unless c.empty? %>
+            <div class="btn btn-school btn-email-study-team" data-toggle='modal' data-target='#contact-study-team-modal' data-email="<%=c.first[:email]%>" data-trial-id="<%=t.id%>" onclick="track('send', 'event', 'email_study_team', 'open', '#{t.system_id}')"><i class="fa fa-envelope"></i> Contact the study team</div>
+          <% end %>
         <% end %>
 
         <a class="btn btn-school btn-more-info" href="https://www.clinicaltrials.gov/ct2/show/study/<%= t.system_id %>" onclick="track('send', 'event', 'ctgov', 'click', '<%= t.system_id %>')" target="_blank"><i class="fa fa-info-circle"></i> See more information</a>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -18,9 +18,16 @@
     <a class="btn btn-school btn-recruitment" href="<%=@study.recruitment_url%>" target="_blank"><i class="fa fa-users" target="_blank"></i> See if you are a good fit for this study</a>
   <% end %>
   <div class="btn btn-school btn-email-me" data-toggle='modal' data-target='#email-me-modal' data-title="<%=@study.display_title%>" data-trial-id="<%=@study.id%>" onclick="track('send', 'event', 'email_me', 'open', '<%= @study.system_id %>')"><i class="fa fa-envelope"></i> Share via email</div>
-  <% unless c.empty? %>
-    <div class="btn btn-school btn-email-study-team" data-toggle='modal' data-target='#contact-study-team-modal' data-email="<%=c.first[:email]%>" data-trial-id="<%=@study.id%>" onclick="track('send', 'event', 'email_study_team', 'open', '#{@study.system_id}')"><i class="fa fa-envelope"></i> Contact the study team</div>
+  
+  <% contact_method = determine_contact_method(@study) %>
+  <% if contact_method == 'url' %>
+    <a class="btn btn-school" href="<%= render_contact_url(@study) %>"><i class="fa fa-envelope"></i> Contact the study team</a>
+  <% elsif contact_method == 'email' %>
+    <% unless c.empty? %>
+      <div class="btn btn-school btn-email-study-team" data-toggle='modal' data-target='#contact-study-team-modal' data-email="<%=c.first[:email]%>" data-trial-id="<%=@study.id%>" onclick="track('send', 'event', 'email_study_team', 'open', '#{@study.system_id}')"><i class="fa fa-envelope"></i> Contact the study team</div>
+    <% end %>
   <% end %>
+
   <a class="btn btn-school btn-more-info" href="https://www.clinicaltrials.gov/ct2/show/study/<%= @study.system_id %>" onclick="track('send', 'event', 'ctgov', 'click', '<%= @study.system_id %>')" target="_blank"><i class="fa fa-info-circle"></i> See more information</a>
 </div>
 <br>

--- a/db/migrate/20200928205903_add_contact_url_to_trials.rb
+++ b/db/migrate/20200928205903_add_contact_url_to_trials.rb
@@ -1,0 +1,6 @@
+class AddContactUrlToTrials < ActiveRecord::Migration[5.2]
+  def change
+  	add_column :study_finder_trials, :contact_url, :string
+  	add_column :study_finder_trials, :contact_url_override, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_23_212151) do
+ActiveRecord::Schema.define(version: 2020_09_28_205903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,6 +209,8 @@ ActiveRecord::Schema.define(version: 2020_07_23_212151) do
     t.string "cancer_yn"
     t.string "pi_name"
     t.string "pi_id"
+    t.string "contact_url"
+    t.string "contact_url_override"
   end
 
   create_table "study_finder_updaters", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Adding a contact url option for each trial. This option can be provided on import or as an override option from within the admin/trial administration interface.

Behavior: In the event a contact_url or contact_url_override value is present on a Trial, the "Contact the Study Team" button will link to the provided URL instead of opening the contact modal. 