### PR TITLE
Showcase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'httparty'
 gem 'rubyzip', '~> 2.0.0'
 gem 'net-ldap', '~> 0.16.1'
 gem 'figaro'
+gem 'active_storage_validations'
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_storage_validations (0.9.0)
+      rails (>= 5.2.0)
     activejob (5.2.4.3)
       activesupport (= 5.2.4.3)
       globalid (>= 0.3.6)
@@ -236,6 +238,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_storage_validations
   breadcrumbs_on_rails
   capybara
   elasticsearch-model

--- a/app/assets/stylesheets/base/globals.css.scss
+++ b/app/assets/stylesheets/base/globals.css.scss
@@ -172,3 +172,17 @@ footer {
   line-height: .5;
   border-radius: .2rem;
 }
+
+.caption-wrapper {
+  background: rgba(255, 255, 255, .40);
+}
+
+.caption-title {
+  font-weight: bold;
+  color: $school_main_color;
+}
+
+.caption-text{
+  color: #000000;
+}
+

--- a/app/controllers/admin/showcase_items_controller.rb
+++ b/app/controllers/admin/showcase_items_controller.rb
@@ -1,0 +1,56 @@
+class Admin::ShowcaseItemsController < ApplicationController
+  
+  def index
+    @showcase_items = ShowcaseItem.all.order(active: :desc).order(:sort_order)
+
+    add_breadcrumb 'Showcase'
+  end
+
+  def new
+    @item = ShowcaseItem.new
+
+    add_breadcrumb 'Showcase', :admin_showcase_items_path
+    add_breadcrumb 'Add Item'
+  end
+
+  def create
+    @item = ShowcaseItem.new(item_params)
+    
+    if @item.save(@item)
+      redirect_to admin_showcase_items_path, flash: { success: 'Item added successfully' }
+    else
+      render action: 'new'
+    end
+  end
+
+  def edit
+    @item = ShowcaseItem.find(params[:id])
+
+    add_breadcrumb 'Showcase', :admin_showcase_items_path
+    add_breadcrumb 'Edit Item'
+  end
+
+  def update
+		@item = ShowcaseItem.find(params[:id])
+
+		if @item.update(item_params)
+      redirect_to admin_showcase_items_path(), flash: { success: 'Item updated successfully' }
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @item = ShowcaseItem.find(params[:id])
+    if @item.destroy
+      redirect_to admin_showcase_items_path, flash: { success: 'Item removed successfully' }
+    else
+      redirect_to admin_showcase_items_path, flash: { error: 'Unable to remove item' }
+    end
+  end
+
+  private
+    def item_params
+      params.require(:showcase_item).permit(:name, :title, :caption, :url, :active, :showcase_image, :sort_order)
+    end
+end

--- a/app/controllers/admin/showcase_items_controller.rb
+++ b/app/controllers/admin/showcase_items_controller.rb
@@ -31,9 +31,9 @@ class Admin::ShowcaseItemsController < ApplicationController
   end
 
   def update
-		@item = ShowcaseItem.find(params[:id])
+    @item = ShowcaseItem.find(params[:id])
 
-		if @item.update(item_params)
+    if @item.update(item_params)
       redirect_to admin_showcase_items_path(), flash: { success: 'Item updated successfully' }
     else
       render 'edit'

--- a/app/controllers/admin/system_controller.rb
+++ b/app/controllers/admin/system_controller.rb
@@ -45,6 +45,9 @@ class Admin::SystemController < ApplicationController
         :display_keywords,
         :display_groups_page,
         :display_study_show_page,
+        :enable_showcase,
+        :show_showcase_indicators,
+        :show_showcase_controls,
         trial_attribute_settings_attributes: [:id, :attribute_label, :display_label_on_list, :display_on_list, :display_if_null_on_list, :display_label_on_show, :display_on_show, :display_if_null_on_show]
       )
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
   def index
+  	@showcase = ShowcaseItem.where(active: true).order(:sort_order)
   end
 
   def splash

--- a/app/models/showcase_item.rb
+++ b/app/models/showcase_item.rb
@@ -1,0 +1,5 @@
+class ShowcaseItem < ApplicationRecord
+	has_one_attached :showcase_image
+
+	validates :showcase_image, content_type: [:png, :jpg, :jpeg]
+end

--- a/app/views/admin/showcase_items/_form.html.erb
+++ b/app/views/admin/showcase_items/_form.html.erb
@@ -5,6 +5,7 @@
     <%= f.input :sort_order, as: :integer, label: 'Order' %>
     <%= f.input :title, hint: '<small><i>(Heading for the showcase item.)</i></small>'.html_safe %>
     <%= f.input :caption, hint: '<small><i>(Text for the showcase item.)</i></small>'.html_safe %>
+    <label for="showcase_item_showcase_image">Image Upload</label><br/>
     <%= f.file_field :showcase_image %>
     <%= f.input :url, label: 'Youtube URL', hint: '<small><i>(Embeddable version of the youtube video URL. Ex. "https://www.youtube.com/watch?v=Ie3jNNDqzzc" becomes "https://www.youtube.com/embed/Ie3jNNDqzzc".)</i></small>'.html_safe %>
   </div>

--- a/app/views/admin/showcase_items/_form.html.erb
+++ b/app/views/admin/showcase_items/_form.html.erb
@@ -1,0 +1,75 @@
+<%= simple_form_for [:admin, @item] do |f| %>
+  <div class="form-group">
+    <label>Name</label>
+    <small><i>(Administrator reference only; will not appear anywhere.)</i></small>
+    <%= f.input :name, label: false %>
+
+    <%= f.input :active, inline_label: 'Display in Showcase' %>
+
+    <label>Order</label>
+    <%= f.input :sort_order, as: :integer, label: false %>
+
+    <label>Title</label>
+    <small><i>(Heading for the showcase item.)</i></small>
+    <%= f.input :title, label: false %>
+    
+    <label>Caption</label>
+    <small><i>(Text for the showcase item.)</i></small>
+    <%= f.input :caption, label: false %>
+
+    <%= f.file_field :showcase_image %>
+    <br/>
+
+    <label>Youtube URL</label>
+    <small><i>(Embeddable version of the youtube video URL. Ex. "https://www.youtube.com/watch?v=Ie3jNNDqzzc" becomes "https://www.youtube.com/embed/Ie3jNNDqzzc".)</i></small>
+    <%= f.input :url, label: false %>
+
+    <% if @item.showcase_image.attached? || !@item.url.blank? %>
+    	<div class="preview_container col-6 d-none d-md-block">
+    		<h4>Preview</h4>
+
+        <div id="showcaseCarousel" class="carousel slide" data-ride="carousel">
+          <% if @system_info.show_showcase_indicators %>
+            <ol class="carousel-indicators">
+              <li data-target="#showcaseCarousel" data-slide-to="0" class="active"></li>
+            </ol>
+          <% end %>
+          <div class="carousel-inner">
+            <div class="carousel-item active">
+              <% if @item.showcase_image.attached? %>
+                <%= image_tag @item.showcase_image, class: 'w-100' %>
+              <% elsif !@item.url.blank? %>
+                <div class="embed-responsive embed-responsive-16by9">asdf
+                  <iframe class="embed-responsive-item" src="<%= @item.url %>" allowfullscreen></iframe>
+                </div>
+              <% end %>
+              <div class="carousel-caption">
+                <div class="caption-wrapper rounded">
+                  <h5 class="caption-title"><%= @item.title.to_s %></h5>
+                  <p class="caption-text"><%= @item.caption.to_s %></p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <% if @system_info.show_showcase_controls %>
+            <a class="carousel-control-prev" href="#showcaseCarousel" role="button" data-slide="prev">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+              <span class="sr-only">Previous</span>
+            </a>
+            <a class="carousel-control-next" href="#showcaseCarousel" role="button" data-slide="next">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+              <span class="sr-only">Next</span>
+            </a>
+          <% end %>
+        </div>
+
+    	</div>
+    <% end %>
+
+  </div>
+
+  <div class="controls">
+    <%= f.submit 'Save', class: 'btn btn-school' %>
+    <%= link_to 'Back to Showcase', admin_showcase_items_path, class: 'btn btn-secondary' %>
+  </div>
+<% end %>

--- a/app/views/admin/showcase_items/_form.html.erb
+++ b/app/views/admin/showcase_items/_form.html.erb
@@ -5,8 +5,10 @@
     <%= f.input :sort_order, as: :integer, label: 'Order' %>
     <%= f.input :title, hint: '<small><i>(Heading for the showcase item.)</i></small>'.html_safe %>
     <%= f.input :caption, hint: '<small><i>(Text for the showcase item.)</i></small>'.html_safe %>
-    <label for="showcase_item_showcase_image">Image Upload</label><br/>
-    <%= f.file_field :showcase_image %>
+    <div class="form-group optional">
+      <label class="control-label optional" for="showcase_item_showcase_image">Image Upload</label><br/>
+      <%= f.file_field :showcase_image %>
+    </div>
     <%= f.input :url, label: 'Youtube URL', hint: '<small><i>(Embeddable version of the youtube video URL. Ex. "https://www.youtube.com/watch?v=Ie3jNNDqzzc" becomes "https://www.youtube.com/embed/Ie3jNNDqzzc".)</i></small>'.html_safe %>
   </div>
 

--- a/app/views/admin/showcase_items/_form.html.erb
+++ b/app/views/admin/showcase_items/_form.html.erb
@@ -1,72 +1,54 @@
 <%= simple_form_for [:admin, @item] do |f| %>
   <div class="form-group">
-    <label>Name</label>
-    <small><i>(Administrator reference only; will not appear anywhere.)</i></small>
-    <%= f.input :name, label: false %>
-
+    <%= f.input :name, hint: '<small><i>(Administrator reference only; will not appear anywhere.)</i></small>'.html_safe %>
     <%= f.input :active, inline_label: 'Display in Showcase' %>
-
-    <label>Order</label>
-    <%= f.input :sort_order, as: :integer, label: false %>
-
-    <label>Title</label>
-    <small><i>(Heading for the showcase item.)</i></small>
-    <%= f.input :title, label: false %>
-    
-    <label>Caption</label>
-    <small><i>(Text for the showcase item.)</i></small>
-    <%= f.input :caption, label: false %>
-
+    <%= f.input :sort_order, as: :integer, label: 'Order' %>
+    <%= f.input :title, hint: '<small><i>(Heading for the showcase item.)</i></small>'.html_safe %>
+    <%= f.input :caption, hint: '<small><i>(Text for the showcase item.)</i></small>'.html_safe %>
     <%= f.file_field :showcase_image %>
-    <br/>
+    <%= f.input :url, label: 'Youtube URL', hint: '<small><i>(Embeddable version of the youtube video URL. Ex. "https://www.youtube.com/watch?v=Ie3jNNDqzzc" becomes "https://www.youtube.com/embed/Ie3jNNDqzzc".)</i></small>'.html_safe %>
+  </div>
 
-    <label>Youtube URL</label>
-    <small><i>(Embeddable version of the youtube video URL. Ex. "https://www.youtube.com/watch?v=Ie3jNNDqzzc" becomes "https://www.youtube.com/embed/Ie3jNNDqzzc".)</i></small>
-    <%= f.input :url, label: false %>
+  <% if @item.showcase_image.attached? || !@item.url.blank? %>
+  	<div class="preview_container col-6 d-none d-md-block">
+  		<h4>Preview</h4>
 
-    <% if @item.showcase_image.attached? || !@item.url.blank? %>
-    	<div class="preview_container col-6 d-none d-md-block">
-    		<h4>Preview</h4>
-
-        <div id="showcaseCarousel" class="carousel slide" data-ride="carousel">
-          <% if @system_info.show_showcase_indicators %>
-            <ol class="carousel-indicators">
-              <li data-target="#showcaseCarousel" data-slide-to="0" class="active"></li>
-            </ol>
-          <% end %>
-          <div class="carousel-inner">
-            <div class="carousel-item active">
-              <% if @item.showcase_image.attached? %>
-                <%= image_tag @item.showcase_image, class: 'w-100' %>
-              <% elsif !@item.url.blank? %>
-                <div class="embed-responsive embed-responsive-16by9">asdf
-                  <iframe class="embed-responsive-item" src="<%= @item.url %>" allowfullscreen></iframe>
-                </div>
-              <% end %>
-              <div class="carousel-caption">
-                <div class="caption-wrapper rounded">
-                  <h5 class="caption-title"><%= @item.title.to_s %></h5>
-                  <p class="caption-text"><%= @item.caption.to_s %></p>
-                </div>
+      <div id="showcaseCarousel" class="carousel slide" data-ride="carousel">
+        <% if @system_info.show_showcase_indicators %>
+          <ol class="carousel-indicators">
+            <li data-target="#showcaseCarousel" data-slide-to="0" class="active"></li>
+          </ol>
+        <% end %>
+        <div class="carousel-inner">
+          <div class="carousel-item active">
+            <% if @item.showcase_image.attached? %>
+              <%= image_tag @item.showcase_image, class: 'w-100' %>
+            <% elsif !@item.url.blank? %>
+              <div class="embed-responsive embed-responsive-16by9">asdf
+                <iframe class="embed-responsive-item" src="<%= @item.url %>" allowfullscreen></iframe>
+              </div>
+            <% end %>
+            <div class="carousel-caption">
+              <div class="caption-wrapper rounded">
+                <h5 class="caption-title"><%= @item.title.to_s %></h5>
+                <p class="caption-text"><%= @item.caption.to_s %></p>
               </div>
             </div>
           </div>
-          <% if @system_info.show_showcase_controls %>
-            <a class="carousel-control-prev" href="#showcaseCarousel" role="button" data-slide="prev">
-              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-              <span class="sr-only">Previous</span>
-            </a>
-            <a class="carousel-control-next" href="#showcaseCarousel" role="button" data-slide="next">
-              <span class="carousel-control-next-icon" aria-hidden="true"></span>
-              <span class="sr-only">Next</span>
-            </a>
-          <% end %>
         </div>
-
-    	</div>
-    <% end %>
-
-  </div>
+        <% if @system_info.show_showcase_controls %>
+          <a class="carousel-control-prev" href="#showcaseCarousel" role="button" data-slide="prev">
+            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+            <span class="sr-only">Previous</span>
+          </a>
+          <a class="carousel-control-next" href="#showcaseCarousel" role="button" data-slide="next">
+            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+            <span class="sr-only">Next</span>
+          </a>
+        <% end %>
+      </div>
+  	</div>
+  <% end %>
 
   <div class="controls">
     <%= f.submit 'Save', class: 'btn btn-school' %>

--- a/app/views/admin/showcase_items/edit.html.erb
+++ b/app/views/admin/showcase_items/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="admin">
+  <h3>Edit Showcase Item</h3>
+  <%= render 'form' %>
+</div>

--- a/app/views/admin/showcase_items/index.html.erb
+++ b/app/views/admin/showcase_items/index.html.erb
@@ -6,7 +6,7 @@
     </div>
   </div>
   
-  <p class="description">This section is where administrators can manage showcase images and youtube videos. These items will appear within the homepage carousel. *Please note - this will replace the main image. Ensure photos are of a proper resolution and aspect ratio.</p>
+  <p class="description">This section is where administrators can manage showcase images and youtube videos. These items will appear within the homepage carousel. *Please note - this will replace the main image. Ensure photos are of a proper resolution and consistent with a 21:9 aspect ratio. </p>
 
   <table class="table table-boredered table-trials">
     <tr>

--- a/app/views/admin/showcase_items/index.html.erb
+++ b/app/views/admin/showcase_items/index.html.erb
@@ -1,0 +1,35 @@
+<div class="admin">
+  <div class="clearfix">
+    <h3 class="pull-left">Showcase</h3>
+    <div class="pull-right header-button">
+      <%= link_to 'Add Item', new_admin_showcase_item_path, class: 'btn btn-school' %>
+    </div>
+  </div>
+  
+  <p class="description">This section is where administrators can manage showcase images and youtube videos. These items will appear within the homepage carousel. *Please note - this will replace the main image. Ensure photos are of a proper resolution and aspect ratio.</p>
+
+  <table class="table table-boredered table-trials">
+    <tr>
+      <th>Name</th>
+      <th>Order</th>
+      <th>Active</th>
+      <th></th>
+    </tr>
+    <% if @showcase_items.empty? %>
+      <tr>
+        <td colspan="3">No showcase items found. Add items manually using the add button above.</td>
+      </tr>
+    <% end %>
+    <% @showcase_items.each do |i| %>
+      <tr>
+        <td><%= i.name %></td>
+        <td><%= i.sort_order %></td>
+        <td><%= i.active ? 'Yes' : 'No' %></td>
+        <td style="width: 150px">
+          <%= link_to 'Edit', edit_admin_showcase_item_path(i.id), class: 'btn btn-primary' %>
+          <%= link_to 'Delete', admin_showcase_item_path(i.id), method: 'delete', class: 'btn btn-danger', data: { confirm:"Are you sure you want to delete this item?" }%>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+</div>

--- a/app/views/admin/showcase_items/new.html.erb
+++ b/app/views/admin/showcase_items/new.html.erb
@@ -1,0 +1,4 @@
+<div class="admin">
+  <h3>Add Showcase Item</h3>
+  <%= render 'form' %>
+</div>

--- a/app/views/admin/system/edit.html.erb
+++ b/app/views/admin/system/edit.html.erb
@@ -72,6 +72,27 @@
           <i>(Create a landing page for each study)</i>
         </small>
         <%= f.input :display_study_show_page, as: :select, label: false, include_blank: false %>
+
+        <label>Display Showcase</label>
+        <small>
+          <i>(Enable a carousel of uploaded images and videos on the site homepage. ***This replaces the main image.)</i>
+        </small>
+        <%= f.input :enable_showcase, as: :select, label: false, include_blank: false %>
+
+        <div class="card card-body bordered">
+          <label>Enable Indicators</label>
+          <small>
+            <i>(Show indicators for each slide on the carousel)</i>
+          </small>
+          <%= f.input :show_showcase_indicators, as: :select, label: false, include_blank: false %>
+
+          <label>Enable Controls</label>
+          <small>
+            <i>(Add controls to allow users to scroll the carousel)</i>
+          </small>
+          <%= f.input :show_showcase_controls, as: :select, label: false, include_blank: false %>
+
+        </div>
       </div>
       <div class="tab-pane fade" id="trial-display" role="tabpanel" aria-labelledby="trial-display-tab">
         <h4> Study Attribute Display Options</h4>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -18,7 +18,7 @@
                 <% if item.showcase_image.attached? %>
                   <%= image_tag item.showcase_image, class: 'w-100' %>
                 <% elsif !item.url.blank? %>
-                  <div class="embed-responsive embed-responsive-16by9">
+                  <div class="embed-responsive embed-responsive-21by9">
                     <iframe class="embed-responsive-item" src="<%= item.url %>" allowfullscreen></iframe>
                   </div>
                 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,54 @@
-<div class="mast d-none d-md-block "></div>
+<% if @system_info.enable_showcase && @showcase.size > 0 %>
+  <div class="d-none d-md-block">
+    <% unless @showcase.empty? %>
+      <div id="showcaseCarousel" class="carousel slide" data-ride="carousel">
+        <% if @system_info.show_showcase_indicators %>
+          <ol class="carousel-indicators">
+            <% @showcase.each_with_index do |item, ix| %>
+              <% unless !item.showcase_image.attached? && item.url.blank? %>
+                <li data-target="#showcase" data-slide-to="<%= ix %>" <% if ix == 0 %>class="active"<% end %> ></li>
+              <% end %>
+            <% end %>
+          </ol>
+        <% end %>
+        <div class="carousel-inner">
+          <% @showcase.each_with_index do |item, ix| %>
+            <% unless !item.showcase_image.attached? && item.url.blank? %>
+              <div class="carousel-item <%= 'active' if ix == 0 %>">
+                <% if item.showcase_image.attached? %>
+                  <%= image_tag item.showcase_image, class: 'w-100' %>
+                <% elsif !item.url.blank? %>
+                  <div class="embed-responsive embed-responsive-16by9">
+                    <iframe class="embed-responsive-item" src="<%= item.url %>" allowfullscreen></iframe>
+                  </div>
+                <% end %>
+                <div class="carousel-caption">
+                  <div class="caption-wrapper rounded">
+                    <h5 class="caption-title"><%= item.title.to_s %></h5>
+                    <p class="caption-text"><%= item.caption.to_s %></p>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+        <% if @system_info.show_showcase_controls %>
+          <a class="carousel-control-prev" href="#showcaseCarousel" role="button" data-slide="prev">
+            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+            <span class="sr-only">Previous</span>
+          </a>
+          <a class="carousel-control-next" href="#showcaseCarousel" role="button" data-slide="next">
+            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+            <span class="sr-only">Next</span>
+          </a>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <div class="mast d-none d-md-block"></div>
+<% end %>
+
 <div class="content home">
   <div class="row home-content">
     <div class="col-md-6 search-form-content">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -35,6 +35,7 @@
             <%= link_to 'Site Administration', admin_sites_path, class: 'nav-link' %>
             <%= link_to 'Disease Site Administration', admin_disease_sites_path, class: 'nav-link' %>
             <%= link_to 'Trial Administration', admin_trials_path, class: 'nav-link' %>
+            <%= link_to 'Showcase', admin_showcase_items_path, class: 'nav-link' if @system_info.enable_showcase %>
             <%= link_to 'Reports', admin_reports_path, class: 'nav-link' %>
           </div>
         </li>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -51,6 +51,7 @@ namespace :figaro do
   task :symlink do
     run "ln -sf #{shared_path}/database.yml #{release_path}/config/database.yml"
     run "ln -sf #{shared_path}/application.yml #{release_path}/config/application.yml"
+    run "ln -sf #{shared_path}/storage #{release_path}/storage"
   end
 
   after "deploy:finalize_update", "figaro:symlink"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,8 +31,7 @@ Rails.application.configure do
   #config.web_console.whitelisted_ips = 'xxx.xxx.xxx.xxx'
   
   # Store files locally.
-  config.active_storage.service = :local
-
+  config.active_storage.service = :temp
 
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,6 +29,10 @@ Rails.application.configure do
 
   #Whitelist your local/development IPs here for the web-console gem
   #config.web_console.whitelisted_ips = 'xxx.xxx.xxx.xxx'
+  
+  # Store files locally.
+  config.active_storage.service = :local
+
 
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,6 +32,9 @@ Rails.application.configure do
   # Generate digests for assets URLs.
   config.assets.digest = true
 
+  # Store files in shared directory.
+  config.active_storage.service = :production
+
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Specifies the header that your server uses for sending files.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.assets.digest = true
 
   # Store files in shared directory.
-  config.active_storage.service = :production
+  config.active_storage.service = :persistent
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -32,6 +32,9 @@ Rails.application.configure do
   # Generate digests for assets URLs.
   config.assets.digest = true
 
+  # Store files in shared directory.
+  config.active_storage.service = :staging
+
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Specifies the header that your server uses for sending files.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.assets.digest = true
 
   # Store files in shared directory.
-  config.active_storage.service = :staging
+  config.active_storage.service = :persistent
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # Store files in shared directory.
-  config.active_storage.service = :test
+  config.active_storage.service = :temp
 
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,4 +36,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Store files in shared directory.
+  config.active_storage.service = :test
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     resources :users
     resources :reports, only: ['index']
     get 'reports/recent_conditions', to: "conditions#recent_as"
+    resources :showcase_items
   end
 
   resources :categories, only: ['index']

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,15 +1,7 @@
-local:
-  service: Disk
-  root: <%= Rails.root.join("tmp/storage") %>
- 
-test:
+temp:
   service: Disk
   root: <%= Rails.root.join("tmp/storage") %>
 
-staging:
-  service: Disk
-  root: <%= Rails.root.join("storage") %>
-
-production:
+persistent:
   service: Disk
   root: <%= Rails.root.join("storage") %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,15 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+ 
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+staging:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+production:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>

--- a/db/migrate/20201006145040_create_showcase_items.rb
+++ b/db/migrate/20201006145040_create_showcase_items.rb
@@ -1,0 +1,19 @@
+class CreateShowcaseItems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :showcase_items do |t|
+    	t.string :name
+    	t.string :title
+    	t.text :caption
+    	t.string :url
+    	t.boolean :active, default: false
+        t.integer :sort_order
+
+    	t.timestamps
+    end
+
+    add_column :study_finder_system_infos, :enable_showcase, :boolean, null: false, default: false
+    add_column :study_finder_system_infos, :show_showcase_indicators, :boolean, null: false, default: true
+    add_column :study_finder_system_infos, :show_showcase_controls, :boolean, null: false, default: false
+  end
+end
+ 

--- a/db/migrate/20201006154045_create_active_storage_tables.rb
+++ b/db/migrate/20201006154045_create_active_storage_tables.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,42 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_28_205903) do
+ActiveRecord::Schema.define(version: 2020_10_06_154045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "showcase_items", force: :cascade do |t|
+    t.string "name"
+    t.string "title"
+    t.text "caption"
+    t.string "url"
+    t.boolean "active", default: false
+    t.integer "sort_order"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "study_finder_condition_groups", id: :serial, force: :cascade do |t|
     t.integer "group_id"
@@ -104,6 +136,9 @@ ActiveRecord::Schema.define(version: 2020_09_28_205903) do
     t.boolean "display_keywords", default: true
     t.boolean "display_groups_page", default: true, null: false
     t.boolean "display_study_show_page", default: false, null: false
+    t.boolean "enable_showcase", default: false, null: false
+    t.boolean "show_showcase_indicators", default: true, null: false
+    t.boolean "show_showcase_controls", default: false, null: false
   end
 
   create_table "study_finder_trial_conditions", id: :serial, force: :cascade do |t|
@@ -248,4 +283,5 @@ ActiveRecord::Schema.define(version: 2020_09_28_205903) do
     t.boolean "display_if_null_on_show", default: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
Adding a bootstrap carousel based showcase. This configurable option will replace the homepage image by default but the view html is easy to refactor to meet the needs of other/additional use cases.

Images and youtube videos may be added to the showcase via an admin interface. Images are saved via Active Storage.