### PR TITLE
Include user-provided email in StudyMailer

### DIFF
--- a/app/mailers/study_mailer.rb
+++ b/app/mailers/study_mailer.rb
@@ -4,6 +4,7 @@ class StudyMailer < ActionMailer::Base
   def contact_team(to, name, email, phone, message, system_id, brief_title, system_info)
     @name = name
     @email = email
+    @phone = phone
     @message = message
     @system_id = system_id
     @brief_title = brief_title

--- a/spec/mailers/study_mailer_spec.rb
+++ b/spec/mailers/study_mailer_spec.rb
@@ -45,5 +45,9 @@ describe StudyMailer do
     it 'assigns @title in the mail body' do
       expect( mail.body.encoded ).to match(trial.brief_title)
     end
+
+    it "includes phone number" do
+      expect(mail.body).to match("123-453-2345")
+    end
   end
 end


### PR DESCRIPTION
Fixes #47.