### PR TITLE
Gracefully handle empty groups

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -77,8 +77,4 @@ class StudiesController < ApplicationController
   def search_params
     params.permit(:page, search: [:category, :q, :healthy_volunteers, :gender])
   end
-
-    def replace_words(q)
-      q.gsub('head ache', 'headache').gsub('/', ' ').gsub('"', ' ')
-    end
 end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -4,40 +4,14 @@ class StudiesController < ApplicationController
   respond_to :html, :json
   
   def index
-    @search_parameters = params[:search].deep_dup if !params[:search].nil?
-    @attribute_settings = TrialAttributeSetting.where(system_info_id: @system_info.id)
-    
-    if !params[:search].nil? and !params[:search][:category].nil?
-      @group = Group.find(params[:search][:category])
-      
-      if @group.conditions_empty?
-        @search_parameters = @search_parameters.except!(:category)
-      end
-    end
+    search_hash = search_params.to_h[:search] || {}
 
-    if params[:search].nil? or params[:search][:q].blank?
-      # Show all trials that are visible, there were no search terms entered.
-      @search_parameters = {} if @search_parameters.nil?
-      @trials = Trial.match_all(@search_parameters).page(params[:page]).results
-    else
-      # There is actually a search term here.
-      # phrase_search = Trial.phrase_search(params[:search]).page(params[:page]).results
-      # unless phrase_search.total == 0
-      #   @trials = phrase_search
-      # else
-        params[:search][:q] = replace_words(@search_parameters[:q])
-        @search_parameters[:q] = params[:search][:q]
+    @attribute_settings = @system_info.trial_attribute_settings
+    @group = Group.where(id: search_hash[:category]).first
+    @trials = Trial.execute_search(search_hash).page(search_params[:page]).results
 
-        @trials = Trial.match_all_search(@search_parameters).page(params[:page]).results
-        # if match_all.total == 0
-        #   @trials = Trial.match_synonyms(params[:search]).page(params[:page]).results
-        # else
-        #   @trials = match_all
-        # end  
-      # end
-      if @trials.total == 0
-        @suggestions = Trial.suggestions(@search_parameters[:q])
-      end
+    if @trials.empty?
+      @suggestions = Trial.suggestions(search_hash[:q] || "")
     end
 
     respond_with(@trials)
@@ -99,6 +73,11 @@ class StudiesController < ApplicationController
   end
 
   private
+
+  def search_params
+    params.permit(:page, search: [:category, :q, :healthy_volunteers, :gender])
+  end
+
     def replace_words(q)
       q.gsub('head ache', 'headache').gsub('/', ' ').gsub('"', ' ')
     end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -23,12 +23,6 @@ class Group < ApplicationRecord
   end
 
   def study_count
-    if conditions_empty?
-      count = Trial.match_all(apply_filters).results.total
-    else
-      count = VwGroupTrialCount.where({ id: id }).first.trial_count.to_i
-    end
-
-    count
+    VwGroupTrialCount.find(id).trial_count
   end
 end

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -252,6 +252,14 @@ class Trial < ApplicationRecord
     )
   end
 
+  def self.execute_search(search_hash = {})
+    if search_hash[:q].blank?
+      match_all(search_hash)
+    else
+      match_all_search(search_hash)
+    end
+  end
+
   def self.match_all(search)
     search(
       query: {

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -294,7 +294,7 @@ class Trial < ApplicationRecord
               must: [
                 {
                   query_string: {
-                    query: search[:q],
+                    query: search[:q].gsub("/", ""),
                     default_operator: "AND",
                     fields: ["display_title", "interventions", "conditions_map", "simple_description", "eligibility_criteria", "system_id", "keywords", "pi_name"]
                   }

--- a/app/models/vw_group_trial_count.rb
+++ b/app/models/vw_group_trial_count.rb
@@ -1,3 +1,4 @@
 class VwGroupTrialCount < ApplicationRecord
   self.table_name = 'vw_study_finder_trial_counts'
+  self.primary_key = 'id'
 end

--- a/config/analysis/synonyms.txt
+++ b/config/analysis/synonyms.txt
@@ -24,6 +24,7 @@ diabetes, type 1, type 2, insulin, glucose, gout, blood sugar
 eye, eyeball, oculus, optic
 glucose, insulin, diabetes, type 1, type 2, gout, blood sugar
 head, brain
+head ache, headache
 heart, valve, atria, cardio, atrium, ventricle, ventricular, fibrilation
 heart attack, cardio, cadriovascular, cardiology, valve, atria, atrium, ventricle, ventricular, flutter, fibrilation, atrial, afib, irregular heartbeat, infarction
 high blood pressure, hypertension, hypertensive

--- a/spec/controllers/studies_controller_spec.rb
+++ b/spec/controllers/studies_controller_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe StudiesController, :type => :controller do
       get :index
       expect(response).to render_template("index")
     end
+
+    it "handles empty groups" do
+      group = Group.create(group_name: "empty group")
+
+      get :index, params: { search: { category: group.id } }
+
+      expect(response).to be_success
+    end
   end
 
   describe "GET #show" do


### PR DESCRIPTION
During setup and/or development a group that contains no conditions
would previously cause an error (#65). This fixes the error, but also
changes the behavior of empty groups.

Before this change the application would check for the no conditions
case and instead return all studies. This is somewhat jarring/unexpected
when you create a new group and see that it contains all studies (both
in the results and the study counts). I think it makes more sense to
make the default to be empty, and only include studies once matching
conditions are added.

StudiesController#index was simplified a bit too during this change. I
think this method had grown over time and built up some unneeded
complexity. A new top-level `Trial.execute_search` (`search` is already
taken by the elasticsearch gem) was introduced to handle the switch
between a search with query text and a search with no query text.
Eventually this model should probably be changed to include a method
that builds out an appropriate search hash that can be fed to the
Elasticsearch `search` method; there's a lot of duplication still here.

[Fixes #65]