### PR TITLE
Default to SMTP for outbound email

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,4 +78,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: ENV['smtp_host'], port: 25 }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -78,4 +78,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: ENV['smtp_host'], port: 25 }
 end


### PR DESCRIPTION
This defaults to using an SMTP server for outbound email, configured via the `smtp_host` environment variable. This was lost at some point through the Rails upgrade.