### PR TITLE
Always set visible flag based on current values

### DIFF
--- a/lib/parsers/ctgov.rb
+++ b/lib/parsers/ctgov.rb
@@ -355,19 +355,8 @@ module Parsers
           end
           
           if f == 'overall_status'
-            if @contents[f] == 'Recruiting'
-              trial.recruiting = true
-              # Only set visible to true if overall_status has CHANGED to 'Recruiting'.
-              if previous_status != @contents[f]
-                trial.visible = true
-              end
-            else
-              trial.recruiting = false
-
-              if previous_status != @contents[f]
-                trial.visible = false
-              end
-            end
+            trial.recruiting = @contents[f] == 'Recruiting'
+            trial.visible = trial.recruiting
           end
         end
       end

--- a/spec/parsers/ctgov_spec.rb
+++ b/spec/parsers/ctgov_spec.rb
@@ -90,7 +90,23 @@ describe Parsers::Ctgov do
       trial2 = Trial.find_by(system_id: 'NCT01678638')
       expect(trial2.visible).to eq(true)
     end
-    
+
+   it "sets visibility correctly regardless of current value" do
+      trial = Trial.create(system_id: "NCT123", overall_status: "Completed", visible: true)
+      p = Parsers::Ctgov.new("NCT123", 1)
+
+      p.set_contents_from_xml("
+        <clinical_study>
+          <overall_status>Completed</overall_status>
+        </clinical_study>
+      ")
+
+      p.process(true)
+      trial.reload
+
+      expect(trial.visible).to eq(false)
+    end
+
     it "parses age ranges correctly when weeks are involved" do
       url = 'https://clinicaltrials.gov/show/NCT01678638?displayxml=true'
       p = Parsers::Ctgov.new( 'NCT01678638', 1)


### PR DESCRIPTION
This changes the ctgov importer to always consider the current
`overall_status` value when determining visibility.

Previously the visible flag was only updated it the parser detected a
change in the overall status. We've found that in production these
can get out of sync; the overall_status becomes something other than
"Recruiting", but the visible flag remains set to true.

The deployment of this change should be accompanied with a one-time
manual update of all trials' visibility flag and a re-index to catch
trials that may no longer be returned from the clinicaltrials.gov
import.