### PR TITLE
Update - Recent Trials Report

### DIFF
--- a/app/controllers/admin/trials_controller.rb
+++ b/app/controllers/admin/trials_controller.rb
@@ -56,10 +56,12 @@ class Admin::TrialsController < ApplicationController
   def recent_as
     @start_date = (params[:start_date].nil?) ? (DateTime.now - 30.days).strftime('%m/%d/%Y') : params[:start_date]
     @end_date = (params[:end_date].nil?) ? DateTime.now.strftime('%m/%d/%Y') : params[:end_date]
-    @trials = Trial.includes(:disease_sites).find_range(@start_date, @end_date)
+    @attribute = params[:attribute] == "created_at" ? "created_at" : "updated_at"
+
+    @trials = Trial.includes(:disease_sites).find_range(@start_date, @end_date, @attribute)
 
     add_breadcrumb 'Trials Administration'
-    add_breadcrumb 'Recently Added'
+    add_breadcrumb 'Recent Updates'
 
     respond_to do |format|
       format.html

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -35,8 +35,8 @@ class Trial < ApplicationRecord
     end
   end
 
-  def self.find_range(start_date, end_date)
-    where('updated_at between ? and ?', start_date, end_date ).order('updated_at DESC')
+  def self.find_range(start_date, end_date, attribute = "updated_at")
+    where("#{Trial.connection.quote_column_name(attribute)} between ? and ?", start_date, end_date ).order("#{Trial.connection.quote_column_name(attribute)} DESC")
   end
 
   def display_title

--- a/app/views/admin/trials/recent_as.html.erb
+++ b/app/views/admin/trials/recent_as.html.erb
@@ -2,21 +2,32 @@
   <div class="clearfix">
     <h3 class="pull-left">Recent Trials (<%= @trials.size %>)</h3>
   </div>
-  <p class="description">This section is where the administrator can review recently imported trials within StudyFinder.</p>
+  <p class="description">This section is where the administrator can review recent trials within StudyFinder. This report details Trials having recently been imported or modified.</p>
   <hr/>
   <div class="clearfix">
     <div class="pull-left">
       <%= form_tag admin_trial_recent_as_path, method: :get do %>
         <div class="pull-left row">
-          <div class="col-md-4">
+          <div class="col-md-3">
             <label>Start Date</label>
             <input id="start_date" name="start_date" class="form-control datepicker" type="text", value="<%=@start_date%>">
           </div>
-          <div class="col-md-4">
+          <div class="col-md-3">
             <label>End Date</label>
             <input id="end_date" name="end_date" class="form-control datepicker" type="text", value="<%=@end_date%>">
           </div>
-          <div class="col-md-4">
+          <div class="col-md-3">
+            <label>Trials</label>
+            <div class="custom-control custom-radio">
+              <input type="radio" id="attribute1" name="attribute" class="custom-control-input" value="updated_at" <% if @attribute == "updated_at"%> checked <% end %> >
+              <label class="custom-control-label" for="attribute1">Recently Modified</label>
+            </div>
+            <div class="custom-control custom-radio">
+              <input type="radio" id="attribute2" name="attribute" class="custom-control-input" value="created_at" <% if @attribute == "created_at"%> checked <% end %> >
+              <label class="custom-control-label" for="attribute2">Recently Imported</label>
+            </div>
+          </div>
+          <div class="col-md-3">
             <button class="btn btn-primary" style='margin-top: 25px;'>Filter Trials</button>
           </div>
         </div>
@@ -31,16 +42,18 @@
       <th>System Id</th>
       <th>Brief Title</th>
       <th>Disease Sites</th>
+      <th>Date Added</th>
       <th>Last Updated</th>
     </tr>
     <% if @trials.empty? %>
-      <tr><td colspan="4">No trials found.</td></tr>
+      <tr><td colspan="5">No trials found.</td></tr>
     <% end %>
     <% @trials.each do |t| %>
       <tr>
         <td><%= t.system_id %></td>
         <td><%= t.display_title %></td>
         <td><%= t.disease_sites.map { |d| "#{d.disease_site_name}" }.join('; ') %></td>
+        <td><%= t.created_at.localtime.strftime('%m/%d/%Y') %></td>
         <td><%= t.updated_at.localtime.strftime('%m/%d/%Y') %></td>
       </tr>
     <% end %>

--- a/app/views/admin/trials/recent_as.xls.erb
+++ b/app/views/admin/trials/recent_as.xls.erb
@@ -5,18 +5,20 @@
   xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
   xmlns:html="http://www.w3.org/TR/REC-html40">
   <Worksheet ss:Name="conditions">
-  	<Table>
+    <Table>
       <Row>
         <Cell><Data ss:Type="String">System ID</Data></Cell>
         <Cell><Data ss:Type="String">Brief Title</Data></Cell>
         <Cell><Data ss:Type="String">Disease Sites</Data></Cell>
+        <Cell><Data ss:Type="String">Date Added</Data></Cell>
         <Cell><Data ss:Type="String">Last Updated</Data></Cell>
       </Row>
       <% @trials.each do |t| %>
-      	<Row>
+        <Row>
           <Cell><Data ss:Type="String"><%= t.system_id %></Data></Cell>
           <Cell><Data ss:Type="String"><%= t.display_title %></Data></Cell>
           <Cell><Data ss:Type="String"><%= t.disease_sites.map { |d| "#{d.disease_site_name}" }.join('; ') %></Data></Cell>
+          <Cell><Data ss:Type="String"><%= t.try(:created_at).strftime('%m/%d/%Y') %></Data></Cell>
           <Cell><Data ss:Type="String"><%= t.try(:updated_at).strftime('%m/%d/%Y') %></Data></Cell>
         </Row>
       <% end %>


### PR DESCRIPTION
Expanding the "Recent Trials" report to optionally search by only recently added trials (created_at instead of updated_at). The default and historic behavior remain consistent. Also adding the Date Imported column to the view and xls export.