### PR TITLE
WickedPDF Deploy Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ departmental_cn: 'USERNAME'
 departmental_pw: 'PASSWORD'
 theme: 'umn'
 es_host: 'elastic.umn.edu'
+wkhtmltopdf_binary_path: 'PATH'
 
 ```
 

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,4 +1,4 @@
 WickedPdf.config = {
   exe_path: ENV['wkhtmltopdf_binary_path'],
-  use_xvfb: true
+  use_xvfb: ENV['wkhtmltopdf_use_xvfb'] == "true"
 }

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,0 +1,4 @@
+WickedPdf.config = {
+  exe_path: ENV['wkhtmltopdf_binary_path'],
+  use_xvfb: true
+}


### PR DESCRIPTION
Adding wickedpdf initializer. Specifying path to the wkhtmltopdf binary via an environment variable (set this in application.yml). Also setting "use_xvfb" to true so wkhtmltopdf commands are wrapped within an xvfb-run command (simulates an X server). Updating readme to include example environment variable.