### PR TITLE
Fix typeahead search suggestions

### DIFF
--- a/app/assets/javascripts/studyfinder.js
+++ b/app/assets/javascripts/studyfinder.js
@@ -83,7 +83,9 @@ function applyTypeahead() {
     },
     {
       name: 'keyword-search',
-      displayKey: 'text',
+      displayKey: function(suggestion) {
+        return suggestion;
+      },
       source: engine.ttAdapter()
     }
   );

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -39,8 +39,7 @@ class StudiesController < ApplicationController
   end
 
   def typeahead
-    typeahead = Trial.typeahead(params[:q])
-    respond_with(typeahead['suggest']['keyword_suggest'][0]['options'])
+    respond_with(Trial.typeahead(params[:q]))
   end
 
   def contact_team

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -331,7 +331,7 @@ class Trial < ApplicationRecord
 
   #  Keyword typeahead
   def self.typeahead(q)
-    search({
+    response_hash = search({
       suggest: {
         keyword_suggest: {
           text: q,
@@ -341,6 +341,12 @@ class Trial < ApplicationRecord
         }
       }
     }).raw_response
+
+    suggestions_hash = Array(response_hash.dig("suggest", "keyword_suggest")).first || {}
+    suggestions = Array((suggestions_hash).dig("options"))
+    unique_suggestions = suggestions.map { |suggestion| suggestion["text"] }.uniq
+
+    unique_suggestions
   end
 
   # Did you mean?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,8 +31,11 @@ Rails.application.routes.draw do
   post 'researchers/trials/search', controller: 'researchers', action: 'search_results', as: :search_trial_results_researchers
   resources :sessions, only: ['new', 'create']
   delete 'sessions/destroy', controller: 'sessions', action: 'destroy', as: 'session' # manually creating this route to exclude requiring an id in the destroy route
-  resources :studies, only: ['index', 'show']
-  get 'studies/typeahead', controller: 'studies', action: 'typeahead'
+  resources :studies, only: ['index', 'show'] do
+    collection do
+      get 'typeahead'
+    end
+  end
   post 'studies/contact_team', controller: 'studies', action: 'contact_team'
   post 'studies/email_me', controller: 'studies', action: 'email_me'
 


### PR DESCRIPTION
This was mostly just a routing problem. When the study show route was added, it started snatching up requests to `/studies/typeahead`. I also took the opportunity to push the complexity of the suggestions structure up into the Trial model. `Trial.typeahead` will now just returns an array of strings instead of the raw Elasticsearch response.

This fix makes the typeahead javascript work again, but the there's still a lot of room for improvement in the quality of suggestions we're getting. This is just step 1.