### PR TITLE
Fix children and adult search filters

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -88,6 +88,6 @@ class StudiesController < ApplicationController
   private
 
   def search_params
-    params.permit(:page, search: [:category, :q, :healthy_volunteers, :gender])
+    params.permit(:page, search: [:category, :q, :healthy_volunteers, :gender, :children, :adults])
   end
 end


### PR DESCRIPTION
These parameters were not included in the permitted params so they were not making it to the search method.

This was missed in the Rails upgrade.