### PR TITLE
Handle basic intervention data

### DIFF
--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -72,7 +72,13 @@ class Trial < ApplicationRecord
   end
 
   def interventions
-    trial_interventions.map { |t| "#{t.intervention_type}: #{t.intervention}" }.join('; ') if trial_interventions.any?
+    trial_interventions.map do |t|
+      if t.intervention_type.blank?
+        t.intervention
+      else
+        "#{t.intervention_type}: #{t.intervention}"
+      end
+    end.join('; ')
   end
 
   def keywords

--- a/spec/models/trial_spec.rb
+++ b/spec/models/trial_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+describe Trial do
+  it "handles nil intervention types" do
+    trial = Trial.new
+    trial.trial_interventions.build(intervention: "Blah")
+
+    expect(trial.interventions).to eq("Blah")
+  end
+end


### PR DESCRIPTION
Intervention data from clinicaltrials.gov comes with a type, name, and description. Data from other sources may just have a single value. This change handles cases where no type data is available.

This change requires a re-index.