### PR TITLE
FAQ and Layout Updates

### DIFF
--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,3 +1,6 @@
+<div class="study-result-hud hide-on-print">
+  <%= render 'shared/refine_search' %>
+</div>
 <div class="row categories">
   <% @groups.each do |g| %>
     <div class="col-md-2">

--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -34,7 +34,7 @@
   <h5>What happens if I decide not to participate in a study after contacting the study team?</h5>
   <p>You can change your mind about participation at any time. Tell the study team contact about your decision and they will no longer contact you.</p>
 
-  <h5>I heard about a University of Minnesota study on tv/radio/podcast. How do I participate?</h5>
+  <h5>I heard about a <%= @system_info.school_name %> study on tv/radio/podcast. How do I participate?</h5>
   <p>Depending on the type of study, it may not be listed on StudyFinder, or it may not be actively recruiting. Send any study details you have (e.g. where study was featured, condition being studied, medication or treatment involved, investigator/physician name) to <a href="mailto:sfinder@umn.edu">sfinder@umn.edu</a>, and the StudyFinder team will try to find additional information.</p>
 
   <h2>Contact Us</h2>

--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -1,8 +1,47 @@
 <div class="contact">
-  <div class="clearfix row">
+
+  <h2>Frequently Asked Questions</h2>
+  <h5>I'd like to participate in research but don't know where to start.</h5>
+  <p>To find open studies at the <%= @system_info.school_name %>, go to the <a href="<%= root_path %>">StudyFinder</a> homepage.</p>
+  <ul>
+    <li>Search for studies that are looking for healthy volunteers by using the “Healthy Volunteers” drop down on the lower left and choosing “yes.” </li>
+    <li>Type a disease or condition into the search box and search for something of interest to you.</li>
+    <li>If you’re not sure what you’re looking for, click on “Search for a Study” to find a list of disease/condition categories, and choose one that may fit your needs.</li>
+    <li>To find out more about a specific study, click on “Contact the Study Team.” </li>
+  </ul>
+
+  <h5>I don’t see any studies relating to a specific condition or disease. Do I have other options?</h5>
+  <p>Research studies are added on an ongoing basis. You can check back and filter by “recently added studies.”</p>
+  <p>You can also take a look at <a href="https://www.clinicaltrials.gov/">ClinicalTrials.gov</a>. This is a site that lists clinical studies that are being conducted around the world. <a href="https://www.clinicaltrials.gov/ct2/search/map/click?map.x=1015&map.y=268&map=NA%3AUS&mapw=1879">Here</a> you can find studies that are being conducted by other Minnesota institutions and healthcare systems. We recommend checking StudyFinder and ClinicalTrials.gov often, as the sites are updated as new studies are added.</p>
+  <p>If you’d like to be contacted about future research opportunities, you may be interested in registering with a nation-wide tool called <a href="https://www.researchmatch.org/">ResearchMatch</a>.</p>
+
+  <h5>I'm interested in getting paid for participating in research. How do I find studies providing compensation?</h5>
+  <p>Many research studies provide some sort of compensation for participation; however, we do not have a way to search for compensation on StudyFinder. Each study will have different eligibility requirements, time commitments, and compensation. If you find a study you may be interested in, click on “Contact the Study Team” and include any questions you have about participation. </p>
+
+  <h5>How do I register to be contacted about future studies?</h5>
+  <p>StudyFinder does not maintain a registry of volunteers. If you’d like to be contacted about future research opportunities, you may be interested in registering with <a href="https://www.researchmatch.org/">ResearchMatch</a>. ResearchMatch is a free and secure online tool that allows national registration for individuals interested in participating in research. ResearchMatch works by emailing you about studies that may be a good match for you. It is always your choice to decide what studies may interest you. You are not required to participate in a study if you join ResearchMatch.</p>
+
+  <h5>What does Phase I, Phase II, Phase III, etc. mean?</h5>
+  <p>After a treatment is tested in the laboratory, it can go to human testing. There are four phases of human testing.</p>
+  <p>Phase I: Researchers test a new drug or treatment in a small group of people (20-80) for the first time to test its safety, identify the maximum tolerated dose, find a safe dosage range and identify side effects.</p>
+  <p>Phase II: The drug or treatment is given to a larger group of people (100-300) to see if it is effective, to further evaluate its safety and to gather additional information regarding safe dose range.</p>
+  <p>Phase III: The drug or treatment is given to large groups of people (1,000-3,000) to confirm its effectiveness, monitor side effects, compare it to commonly used treatments and collect information that will allow the drug or treatment to be used safely.</p>
+  <p>Phase IV: During this phase, investigators are looking for additional information, including the drug or treatment’s risks, benefits, and optimal use. This trial may occur after the drug or treatment has been approved for use by the FDA.</p>
+
+  <h5>I contacted a study team but have not heard back. What should I do?</h5>
+  <p>Research coordinators may manage multiple studies at the same time. If you have not heard back within two business days, please contact the StudyFinder team to ask for assistance.</p>
+
+  <h5>What happens if I decide not to participate in a study after contacting the study team?</h5>
+  <p>You can change your mind about participation at any time. Tell the study team contact about your decision and they will no longer contact you.</p>
+
+  <h5>I heard about a University of Minnesota study on tv/radio/podcast. How do I participate?</h5>
+  <p>Depending on the type of study, it may not be listed on StudyFinder, or it may not be actively recruiting. Send any study details you have (e.g. where study was featured, condition being studied, medication or treatment involved, investigator/physician name) to <a href="mailto:sfinder@umn.edu">sfinder@umn.edu</a>, and the StudyFinder team will try to find additional information.</p>
+
+  <h2>Contact Us</h2>
+  <div class="row">  
     <div class="col-md-12 col-sm-12 col-lg-6">
-      <h2>Contact Us</h2>
-      <p>We would love to hear from you!</p>
+      
+      <p>For general questions about participating in research, feel free to contact the StudyFinder team</p>
       <%= form_tag contact_index_path, method: :post do %>
         <div class="form-group">
           <label class="control-label">Name (*)</label>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,7 @@
 <footer>
   <div id="footer-content">
-    <span class="text-muted">StudyFinder was developed by the <a href="http://www.ctsi.umn.edu" target="_blank">Clinical and Translational Science Institute (CTSI)</a>, and is supported by the NIH Clinical and Translational Science Award at the University of Minnesota: UL1TR000114.</span>
+    <p>StudyFinder was developed by the <a href="http://www.ctsi.umn.edu" target="_blank">Clinical and Translational Science Institute (CTSI)</a>, and is supported by the NIH Clinical and Translational Science Award at the University of Minnesota: UL1TR000114.</p>
+    <span>If you'd like to learn more about using StudyFinder at your institution, please contact <a href="mailto:sfinder@umn.edu">sfinder@umn.edu</a>.</span>
     <span class="credentials">
       <% if logged_in? %>
         <%= link_to 'Sign Out', session_path, data: { method: "delete" } %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,15 +13,15 @@
       <div class="w-100 d-block d-md-none"></div>
       <li class="nav-item">
         <% if @system_info.display_groups_page %>
-          <li class="nav-item"><a href="<%= categories_path %>" class="nav-link <%= 'active' if ['categories','studies'].include? params[:controller] %>">Search for a Study</a></li>
+          <li class="nav-item"><a href="<%= categories_path %>" class="nav-link <%= 'active' if ['categories','studies'].include? params[:controller] %>">Find a Study</a></li>
         <% else %>
-          <li class="nav-item"><a href="<%= studies_path %>" class="nav-link <%= 'active' if ['categories','studies'].include? params[:controller] %>">Search for a Study</a></li>
+          <li class="nav-item"><a href="<%= studies_path %>" class="nav-link <%= 'active' if ['categories','studies'].include? params[:controller] %>">Find a Study</a></li>
         <% end %>
       </li>
       <div class="w-100 d-block d-md-none"></div>
       <li class="nav-item"><a href="<%= researchers_path %>" class="nav-link <%= 'active' if params[:controller] == 'researchers' %>">For Researchers</a></li>
       <div class="w-100 d-block d-md-none"></div>
-      <li class="nav-item"><a href="<%= contact_index_path %>" class="nav-link <%= 'active' if params[:controller] == 'contact' %>">Contact Us</a></li>
+      <li class="nav-item"><a href="<%= contact_index_path %>" class="nav-link <%= 'active' if params[:controller] == 'contact' %>">Help</a></li>
       <div class="w-100 d-block d-md-none"></div>
       <% if is_admin? %>
         <li class="nav-item dropdown">

--- a/app/views/shared/_refine_search.html.erb
+++ b/app/views/shared/_refine_search.html.erb
@@ -1,37 +1,48 @@
 <%= form_tag studies_path, method: :get, class: 'search-form' do %>
   <div class="results-header">
-    <h3>Refine your search</h3>
     <div class="clearfix">
-      <h3 class="pull-left"><i class="fa fa-search"></i><%= text_field_tag 'search[q]', search_value(params[:search], 'q'), class: 'input-search typeahead', autocomplete: 'off' %></h3>
-      <div class="form-group pull-left healthy-volunteers">
-        <label for="search_healthy_volunteers" data-toggle='popover' data-title='Healthy Volunteer' data-content='A person who does not have the condition or disease being studied.' data-placement='top'>Healthy Volunteers <i class="fa fa-question-circle"></i></label>
-        <% healthy_voulunteers = params[:search]['healthy_volunteers'] if !params[:search].nil? and !params[:search]['healthy_volunteers'].nil? %>
-        <select id="search_heathy_volunteers" name="search[healthy_volunteers]" class="form-control">
-          <option value=''>Please Select</option>
-          <option value='1' <% if healthy_voulunteers == '1' %>selected<%end%> >Yes</option>
-          <option value='0' <% if healthy_voulunteers == '0' %>selected<%end%> >No</option>
-          <option value=''>No Preference</option>
-        </select>
-        <label class="gender-label">Sex</label>
-        <% gender = params[:search]['gender'] if !params[:search].nil? and !params[:search]['gender'].nil? %>
-        <select id="gender" name="search[gender]" class="form-control">
-          <option value=''>Any</option>
-          <option value='Female' <% if gender == 'Female' %>selected<%end%> >Female</option>
-          <option value='Male' <% if gender == 'Male' %>selected<%end%> >Male</option>
-        </select>
+      <div class="row">
+
+        <div class="col-12 col-lg-4 col-md-5">
+          <h3 class=""><i class="fa fa-search"></i><%= text_field_tag 'search[q]', search_value(params[:search], 'q'), class: 'input-search typeahead', autocomplete: 'off' %></h3>
+        </div>
+        
+        <div class="col-12 col-lg-2 col-md-3">
+          <label for="search_healthy_volunteers" data-toggle='popover' data-title='Healthy Volunteer' data-content='A person who does not have the condition or disease being studied.' data-placement='top'>Healthy Volunteers <i class="fa fa-question-circle"></i></label>
+          <% healthy_voulunteers = params[:search]['healthy_volunteers'] if !params[:search].nil? and !params[:search]['healthy_volunteers'].nil? %>
+          <select id="search_heathy_volunteers" name="search[healthy_volunteers]" class="form-control">
+            <option value=''>Please Select</option>
+            <option value='1' <% if healthy_voulunteers == '1' %>selected<%end%> >Yes</option>
+            <option value='0' <% if healthy_voulunteers == '0' %>selected<%end%> >No</option>
+            <option value=''>No Preference</option>
+          </select>
+          <label class="gender-label">Sex</label>
+          <% gender = params[:search]['gender'] if !params[:search].nil? and !params[:search]['gender'].nil? %>
+          <select id="gender" name="search[gender]" class="form-control">
+            <option value=''>Any</option>
+            <option value='Female' <% if gender == 'Female' %>selected<%end%> >Female</option>
+            <option value='Male' <% if gender == 'Male' %>selected<%end%> >Male</option>
+          </select>
+        </div>
+
+        <div class="col-12 col-lg-3 col-md-4">
+          <br/>
+          <label class="checkbox"><%= check_box_tag 'search[children]', "", (!params[:search].nil? and !params[:search]['children'].nil?) %> Children (age &lt; 18 years)</label>
+          <br>
+          <label class="checkbox"><%= check_box_tag 'search[adults]', "", (!params[:search].nil? and !params[:search]['adults'].nil?) %> Adults (age &ge; 18 years)</label>
+        </div>
+          
+        <div class="col-12 col-lg-3">
+          <div class="buttons ">
+            <% if !params[:search].nil? and !params[:search][:category].nil? %>
+              <input type='hidden' name='search[category]' value="<%=params[:search][:category]%>"></input>
+            <% end %>
+            <%= submit_tag 'Search', class: 'btn btn-lg btn-school-inverse btn-search' %>
+            <%= link_to 'Clear', studies_path, class: 'btn btn-lg btn-light' %>
+          </div>
+        </div>
+
       </div>
-      <div class="age-ranges pull-left">
-        <label class="checkbox"><%= check_box_tag 'search[children]', "", (!params[:search].nil? and !params[:search]['children'].nil?) %> Children (age &lt; 18 years)</label>
-        <br>
-        <label class="checkbox"><%= check_box_tag 'search[adults]', "", (!params[:search].nil? and !params[:search]['adults'].nil?) %> Adults (age &ge; 18 years)</label>
-      </div>
-      <% if !params[:search].nil? and !params[:search][:category].nil? %>
-        <input type='hidden' name='search[category]' value="<%=params[:search][:category]%>"></input>
-      <% end %>
-    </div>
-    <div class="buttons">
-      <%= submit_tag 'Search', class: 'btn btn-lg btn-school-inverse btn-search' %>
-      <%= link_to 'Clear', studies_path, class: 'btn btn-lg btn-light' %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_refine_search.html.erb
+++ b/app/views/shared/_refine_search.html.erb
@@ -16,7 +16,7 @@
             <option value='0' <% if healthy_voulunteers == '0' %>selected<%end%> >No</option>
             <option value=''>No Preference</option>
           </select>
-          <label class="gender-label">Sex</label>
+         <label class="gender-label" for="gender">Sex</label>
           <% gender = params[:search]['gender'] if !params[:search].nil? and !params[:search]['gender'].nil? %>
           <select id="gender" name="search[gender]" class="form-control">
             <option value=''>Any</option>


### PR DESCRIPTION
Updating the "Contact Us" functionality. "Contact Us" becomes "Help" and users are prompted with a FAQ section before the contact form is displayed.

Adding the "refine search" box from study results page to the Categories page as it gives users another method to search for studies.

Updating layout elements according to wishes of the studyfinder team.