### PR TITLE
Search trial.pi_id

### DIFF
--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -298,7 +298,7 @@ class Trial < ApplicationRecord
                   query_string: {
                     query: search[:q].gsub("/", ""),
                     default_operator: "AND",
-                    fields: ["display_title", "interventions", "conditions_map", "simple_description", "eligibility_criteria", "system_id", "keywords", "pi_name"]
+                    fields: ["display_title", "interventions", "conditions_map", "simple_description", "eligibility_criteria", "system_id", "keywords", "pi_name", "pi_id"]
                   }
                 },
                 { bool: { filter: filters(search) } },


### PR DESCRIPTION
This field is usually not displayed in search results, but adding allows
users to search on a PI's email address (or whatever is populated here)
in order link to a list of studies for a given PI.