### PR TITLE
Study Description Formatting

### DIFF
--- a/app/assets/stylesheets/pages/studies.css.scss
+++ b/app/assets/stylesheets/pages/studies.css.scss
@@ -205,16 +205,17 @@
   .btn-subgroup {
     margin: 5px;
   }
+}
 
-  .eligibility-line-break {
-    display: block;
-    content: " ";
-    margin: 4px 0;
-  }
 
-  .eligibility-header {
-    margin: 10px 0;
-  }
+.eligibility-line-break {
+  display: block;
+  content: " ";
+  margin: 4px 0;
+}
+
+.eligibility-header {
+  margin: 10px 0;
 }
 
 .trial-cta-options {

--- a/app/assets/stylesheets/pages/studies.css.scss
+++ b/app/assets/stylesheets/pages/studies.css.scss
@@ -74,6 +74,11 @@
     background: $highlight_color;
   }
 
+  h1 {
+    font-size: 1.75rem;
+    margin-bottom: 1em;
+  }
+
   h4{
     a {
       text-decoration: underline;
@@ -239,4 +244,8 @@
 
 .strong {
   font-weight: bold;
+}
+
+.button-holder {
+  margin-top: 1.5em;
 }

--- a/app/assets/stylesheets/pages/studies.css.scss
+++ b/app/assets/stylesheets/pages/studies.css.scss
@@ -233,6 +233,10 @@
   display: inline-block;
 }
 
+.popover{
+  max-width: 75%;
+}
+
 .strong {
   font-weight: bold;
 }

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -146,16 +146,6 @@ module StudiesHelper
     return rendered.html_safe
   end
 
-  def render_study_description(study)
-    if !study.simple_description.nil? && study.simple_description.length > 500
-      rendered = '<div>' + study.simple_description.truncate(500) + '<i class="fa fa-question-circle" class="study-desc-popover" data-toggle="popover" data-title="Study Description" data-content="' + study.simple_description + '" data-placement="top"></i></div>'
-    else 
-      rendered = study.simple_description.to_s
-    end
-    
-    return rendered.html_safe
-  end
-
   def render_age_display(study)
      return (study.respond_to?(:min_age_unit) && study.respond_to?(:max_age_unit)) ? age_display_units(study.min_age_unit, study.max_age_unit) : age_display(study.min_age, study.max_age)
   end

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -146,6 +146,16 @@ module StudiesHelper
     return rendered.html_safe
   end
 
+  def render_study_description(study)
+    if !study.simple_description.nil? && study.simple_description.length > 500
+      rendered = '<div>' + study.simple_description.truncate(500) + '<i class="fa fa-question-circle" class="study-desc-popover" data-toggle="popover" data-title="Study Description" data-content="' + study.simple_description + '" data-placement="top"></i></div>'
+    else 
+      rendered = study.simple_description.to_s
+    end
+    
+    return rendered.html_safe
+  end
+
   def render_age_display(study)
      return (study.respond_to?(:min_age_unit) && study.respond_to?(:max_age_unit)) ? age_display_units(study.min_age_unit, study.max_age_unit) : age_display(study.min_age, study.max_age)
   end

--- a/app/views/studies/_description.html.erb
+++ b/app/views/studies/_description.html.erb
@@ -1,0 +1,15 @@
+<%
+  setting = Array(settings.filter { |s| s.attribute_key == "simple_description" }).first
+  page = controller.action_name == "index" ? "list" : controller.action_name
+  display = !!setting.attributes["display_on_#{page}"]
+  display_label = !!setting["display_label_on_#{page}"]
+%>
+
+<% if display && !study.simple_description.blank? %>
+  <div data-attribute-name="simple_description">
+    <% if display_label %>
+      <label class="nomargin strong mb-n1">Description:</label>
+    <% end %>
+    <p><%= study.simple_description %></p>
+  </div>
+<% end %>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -78,7 +78,7 @@
       </h4>
       
       <% c = determine_contacts(t) %>
-      <%= render_attribute(@attribute_settings, 'simple_description', 'list', t.simple_description, true) %>
+      <%= render "description", study: t, settings: @attribute_settings %>
       <%= render_attribute(@attribute_settings, 'overall_status', 'list', t.overall_status) %>
       <%= render_attribute(@attribute_settings, 'contacts', 'list', contacts_display(c), true) %>
       <%= render_attribute(@attribute_settings, 'principal_investigator', 'list', t.pi_name) %>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -1,34 +1,26 @@
 <% c = determine_contacts(@study) %>
 
-<div class="container study-results">
-  <div class="row">
-    <div class="col-md-6">
-      <h3><%= @study.brief_title %></h3>
-      <%= render_attribute(@attribute_settings, 'overall_status', 'show', @study.overall_status) %>
-      <%= render_attribute(@attribute_settings, 'simple_description', 'show', render_study_description(@study)) %>
+<div class="container study-results clearfix">
+  <h1><%= @study.brief_title %></h1>
+  <%= image_tag 'flag.jpg', class: 'bordered float-lg-right ml-4 mb-4' %>
+  <%= render_attribute(@attribute_settings, 'overall_status', 'show', @study.overall_status) %>
+  <%= render "description", study: @study, settings: @attribute_settings %>
 
-      <div class="button-holder hide-on-print">
-        <% contact_method = determine_contact_method(@study) %>
-        <% if contact_method == 'url' %>
-          <a class="btn btn-school" href="<%= render_contact_url(@study) %>"><i class="fa fa-envelope"></i> Contact the study team</a>
-        <% elsif contact_method == 'email' %>
-          <% unless c.empty? %>
-            <div class="btn btn-school btn-email-study-team" data-toggle='modal' data-target='#contact-study-team-modal' data-email="<%=c.first[:email]%>" data-trial-id="<%=@study.id%>" onclick="track('send', 'event', 'email_study_team', 'open', '#{@study.system_id}')"><i class="fa fa-envelope"></i> Contact the study team</div>
-          <% end %>
-        <% end %>
-        <% unless @study.recruitment_url.blank? %>
-          <a class="btn btn-school btn-recruitment" href="<%=@study.recruitment_url%>" target="_blank"><i class="fa fa-users" target="_blank"></i> Visit the Study Website</a>
-        <% end %>
-      </div>
-      <%= render 'social', study: @study %>
-    </div>
-    <div class="col-6 d-none d-md-block">
-      <%= image_tag 'flag.jpg', class: 'bordered' %>
-    </div>
+  <div class="button-holder hide-on-print">
+    <% contact_method = determine_contact_method(@study) %>
+    <% if contact_method == 'url' %>
+      <a class="btn btn-school" href="<%= render_contact_url(@study) %>"><i class="fa fa-envelope"></i> Contact the study team</a>
+    <% elsif contact_method == 'email' %>
+      <% unless c.empty? %>
+        <div class="btn btn-school btn-email-study-team" data-toggle='modal' data-target='#contact-study-team-modal' data-email="<%=c.first[:email]%>" data-trial-id="<%=@study.id%>" onclick="track('send', 'event', 'email_study_team', 'open', '#{@study.system_id}')"><i class="fa fa-envelope"></i> Contact the study team</div>
+      <% end %>
+    <% end %>
+    <% unless @study.recruitment_url.blank? %>
+      <a class="btn btn-school btn-recruitment" href="<%=@study.recruitment_url%>" target="_blank"><i class="fa fa-users" target="_blank"></i> Visit the Study Website</a>
+    <% end %>
   </div>
+  <%= render 'social', study: @study %>
 </div>
-
-
 
 <ul class="nav nav-tabs hide-on-print" id="myTab" role="tablist">
   <li class="nav-item active"><a class="nav-link active" id="eligibility-tab" data-toggle="tab" href="#eligibility" role="tab" aria-controls="eligibility" aria-selected="true">Eligibility Criteria</a></li>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -5,8 +5,7 @@
     <div class="col-md-6">
       <h3><%= @study.brief_title %></h3>
       <%= render_attribute(@attribute_settings, 'overall_status', 'show', @study.overall_status) %>
-      <%= render_attribute(@attribute_settings, 'simple_description', 'show', @study.simple_description) %>
-
+      <%= render_attribute(@attribute_settings, 'simple_description', 'show', render_study_description(@study)) %>
 
       <div class="button-holder hide-on-print">
         <% contact_method = determine_contact_method(@study) %>


### PR DESCRIPTION
In the event a study description is more than 500 characters this will truncate the description and add a popover with the entire description contents to the page. This is to prevent super-long descriptions from disrupting the page layout and user experience.