### PR TITLE
Fix flash messages

### DIFF
--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |type, message| %>
   <% unless message.empty? %>
-  <div class="alert <%= bootstrap_class_for(type) %> fade in">
+  <div class="alert <%= bootstrap_class_for(type) %> fade show">
     <i class="fa <%= bootstrap_icon_for(type) %>"></i>
     <% if message.kind_of? Array %>
       <ul>


### PR DESCRIPTION
These have been invisible since the Bootstrap 4 upgrade. The
fade-to-appear classes have changed from `fade in` to `fade show`.

Fixes #88.