### PR TITLE
Don't import trials when loading edit form

### DIFF
--- a/app/controllers/admin/trials_controller.rb
+++ b/app/controllers/admin/trials_controller.rb
@@ -85,21 +85,10 @@ class Admin::TrialsController < ApplicationController
   end
 
   def edit
-
-    # If editing, let's take the opportunity to update the trial from ctgov.
-    trial = Parsers::Ctgov.new(params[:id])
-    trial.load
-    trial.process
-
     @trial = Trial.find_by(system_id: params[:id])
 
     if @trial.nil?
       redirect_to admin_trials_path, alert: 'This trial does not exist'
-    end
-
-    if @trial.parser.klass == 'Parsers::Ctgov' && !Parser.find_by({ klass: 'Parsers::Oncore'}).blank?
-      @oncore = Parsers::Oncore.new(@trial.system_id)
-      @oncore.load(true)
     end
 
     add_breadcrumb 'Trials Administration', :admin_trials_path


### PR DESCRIPTION
Just viewing the edit form should not re-import anything. It should have
no side-effects. The trial edit form is used to override certain values and 
re-importing on the edit form load completely cancels this out. If you
override a value, it saves, redirects you to the edit form, and un-does
the change you just made.