### PR TITLE
Add healthy_volunteers override option

### DIFF
--- a/app/controllers/admin/trials_controller.rb
+++ b/app/controllers/admin/trials_controller.rb
@@ -109,7 +109,7 @@ class Admin::TrialsController < ApplicationController
     def trial_params
       params.require(:trial).permit(
         :simple_description, :visible, 
-        :featured, :recruiting, :contact_override, :cancer_yn,
+        :featured, :recruiting, :contact_override, :cancer_yn, :healthy_volunteers_override,
         :contact_override_first_name, :contact_override_last_name, :pi_name, :pi_id, :recruitment_url, :contact_url_override,
         :reviewed, :irb_number, site_ids: [], disease_site_ids: [])
     end

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -4,6 +4,8 @@ class Trial < ApplicationRecord
 
   self.table_name = 'study_finder_trials'
 
+  before_save :update_healthy_volunteers
+
   include Elasticsearch::Model
   include Elasticsearch::Model::Callbacks
 
@@ -416,5 +418,13 @@ class Trial < ApplicationRecord
       conditions_map: { number_of_fragments: 0 },
       eligibility_criteria: { number_of_fragments: 0 }
     }
+  end
+
+  def update_healthy_volunteers
+    self.healthy_volunteers = if !healthy_volunteers_override.nil?
+                                healthy_volunteers_override
+                              else
+                                healthy_volunteers_imported
+                              end
   end
 end

--- a/app/views/admin/trials/edit.html.erb
+++ b/app/views/admin/trials/edit.html.erb
@@ -51,6 +51,7 @@
       <%= f.input :recruitment_url %>
       <%= f.input :irb_number, label: 'IRB Number' %>
     <% end %>
+    <%= f.input :healthy_volunteers_override, as: :select, include_blank: true %>
     <%= f.input :visible, as: :select %>
     <%= f.input :featured, as: :select, collection: [['No', 0],['Yes', 1]], include_blank: false %>
     <%= f.input :cancer_yn, as: :select, collection: [['Yes', 'Y'],['No', 'N']], include_blank: true, label: 'Cancer Y/N' %>

--- a/db/migrate/20210302004918_add_healthy_volunteers_override_to_trials.rb
+++ b/db/migrate/20210302004918_add_healthy_volunteers_override_to_trials.rb
@@ -1,0 +1,6 @@
+class AddHealthyVolunteersOverrideToTrials < ActiveRecord::Migration[5.2]
+  def change
+    add_column :study_finder_trials, :healthy_volunteers_imported, :boolean, default: nil
+    add_column :study_finder_trials, :healthy_volunteers_override, :boolean, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_14_144059) do
+ActiveRecord::Schema.define(version: 2021_03_02_004918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -247,6 +247,8 @@ ActiveRecord::Schema.define(version: 2021_01_14_144059) do
     t.string "pi_id"
     t.string "contact_url"
     t.string "contact_url_override"
+    t.boolean "healthy_volunteers_imported"
+    t.boolean "healthy_volunteers_override"
   end
 
   create_table "study_finder_updaters", id: :serial, force: :cascade do |t|

--- a/lib/parsers/ctgov.rb
+++ b/lib/parsers/ctgov.rb
@@ -189,9 +189,9 @@ module Parsers
 
       if @contents['eligibility'].has_key?('healthy_volunteers')
         if @contents['eligibility']['healthy_volunteers'] == 'Accepts Healthy Volunteers'
-          trial.healthy_volunteers = true
+          trial.healthy_volunteers_imported = true
         else
-          trial.healthy_volunteers = false
+          trial.healthy_volunteers_imported = false
         end
       end
 

--- a/spec/models/trial_spec.rb
+++ b/spec/models/trial_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe Trial do
+  it "calculates healthy_volunteers" do
+    trial = Trial.create(healthy_volunteers_imported: false)
+    expect(trial.healthy_volunteers).to be false
+  end
+
+  it "overrides healthy_volunteers" do
+    trial = Trial.create(healthy_volunteers_imported: false)
+    trial.update(healthy_volunteers_override: true)
+    expect(trial.healthy_volunteers).to be true
+  end
+end


### PR DESCRIPTION
This allows administrators to override the `accepts healthy volunteers?`
field for a trial. Occasionally, studies that will meet their healthy
volunteer enrollment goals and will want to continue recruiting
non-healthy participants without modifying the entry in clinicaltrials.gov.

I don't love that this solution introduces two new database columns and
changes the surface area of the importer. However based on recent
conversations, I expect more of these kinds of overrides to be
introduced. When we get some more to implement I'd like to explore
building a more robust but simple override mechanism that plays nicely
with Elasticsearch.