### PR TITLE
Conditionally render clinicaltrials.gov button

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ departmental_pw: 'PASSWORD'
 theme: 'umn'
 ELASTICSEARCH_URL: 'elastic.umn.edu'
 wkhtmltopdf_binary_path: 'PATH'
+DEFAULT_URL_HOST: 'yourstudyfinder.example.com' # Used in email links/URLs
 
 ```
 

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -367,6 +367,17 @@ class Trial < ApplicationRecord
     }).raw_response
   end
 
+  def has_nct_number?
+    self.class.is_nct_number?(system_id)
+  end
+
+  # This only exists as a class method so we can use this logic in the search
+  # results page without instantiating a Trial object for every result. Actual
+  # Trial instances should use `trial.has_nct_number?`
+  def self.is_nct_number?(value)
+    value.to_s.upcase.starts_with?("NCT")
+  end
+
   private
 
   def self.filters(search)

--- a/app/views/studies/_clinicaltrialsgov_button.html.erb
+++ b/app/views/studies/_clinicaltrialsgov_button.html.erb
@@ -1,0 +1,6 @@
+<% if Trial.is_nct_number?(study.system_id) %>
+  <a class="btn btn-school btn-more-info" href="https://www.clinicaltrials.gov/ct2/show/study/<%= study.system_id %>" onclick="track('send', 'event', 'ctgov', 'click', '<%= study.system_id %>')" target="_blank">
+    <i class="fa fa-info-circle"></i>
+    See this study on ClinicalTrials.gov
+  </a>
+<% end %>

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -109,7 +109,7 @@
 
         <div class="btn btn-school btn-email-me" data-toggle='modal' data-target='#email-me-modal' data-title="<%=t.display_title%>" data-trial-id="<%=t.id%>" onclick="track('send', 'event', 'email_me', 'open', '<%= t.system_id %>')"><i class="fa fa-envelope"></i> Share via email</div>
 
-        <a class="btn btn-school btn-more-info" href="https://www.clinicaltrials.gov/ct2/show/study/<%= t.system_id %>" onclick="track('send', 'event', 'ctgov', 'click', '<%= t.system_id %>')" target="_blank"><i class="fa fa-info-circle"></i> See this study on ClinicalTrials.gov</a>
+        <%= render partial: "clinicaltrialsgov_button", locals: { study: t } %>
 
         <% if !t.trial_locations.empty? && @system_info.display_all_locations == true %>
           <div class="btn btn-school btn-all-locations">

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -53,8 +53,7 @@
     <%= render_attribute(@attribute_settings, 'phase', 'show', @study.phase) %>
     <%= render_attribute(@attribute_settings, 'irb_number', 'show', @study.irb_number) %>
     <%= render_attribute(@attribute_settings, 'system_id', 'show', @study.system_id) %>
-
-    <a class="btn btn-school btn-more-inf hide-on-print" href="https://www.clinicaltrials.gov/ct2/show/study/<%= @study.system_id %>" onclick="track('send', 'event', 'ctgov', 'click', '<%= @study.system_id %>')" target="_blank"><i class="fa fa-info-circle"></i> See this study on ClinicalTrials.gov</a>
+    <%= render partial: "clinicaltrialsgov_button", locals: { study: @study } %>
   </div>
 </div>
 <br>

--- a/app/views/study_mailer/email_me.html.erb
+++ b/app/views/study_mailer/email_me.html.erb
@@ -21,4 +21,9 @@
 <p><b>Message:</b>
 <p><%= @message %></p>
 <hr />
-<a href="https://www.clinicaltrials.gov/ct2/show/study/<%= @trial.system_id %>" class="btn btn-school" target="_blank">See more information</a>
+
+<% if SystemInfo.first.display_study_show_page? %>
+  <a href="<%= study_url(@trial) %>">See more information</a>
+<% else %>
+  <a href="<%= studies_url(search: { q: @trial.system_id } ) %>">See more information</a>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,4 +40,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.action_mailer.delivery_method = :file
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,4 +81,5 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { address: ENV['smtp_host'], port: 25 }
+  config.action_mailer.default_url_options = { host: ENV['DEFAULT_URL_HOST'], protocol: ENV['DEFAULT_URL_PROTOCOL'] || 'https' }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -81,4 +81,5 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { address: ENV['smtp_host'], port: 25 }
+  config.action_mailer.default_url_options = { host: ENV['DEFAULT_URL_HOST'], protocol: ENV['DEFAULT_URL_PROTOCOL'] || 'https' }
 end

--- a/spec/models/trial_spec.rb
+++ b/spec/models/trial_spec.rb
@@ -11,4 +11,10 @@ describe Trial do
     trial.update(healthy_volunteers_override: true)
     expect(trial.healthy_volunteers).to be true
   end
+
+  it "detects NCT numbers" do
+    expect(Trial.new(system_id: "thisisnotannctnumber").has_nct_number?).to be false
+    expect(Trial.new(system_id: "NCT123").has_nct_number?).to be true
+    expect(Trial.new(system_id: "nct123").has_nct_number?).to be true
+  end
 end


### PR DESCRIPTION
Not all studies will have an NCT number in the `system_id` field. While eventually we'll want to build some new data structures to more gracefully handle data imports from multiple systems, this change will let us immediately accommodate Mayo studies on healthstudiesmn.org.

This seemingly simple change sprawled a bit from the buttons. Because the "share via email" mailer included a clinicaltrials.gov link, we've just replaced it with a link to StudyFinder itself (either the show page if enabled, or a single-item search). Rendering this link URL in the mailer requires us to introduce a new environment variable to set the host (and optionally the protocol): `DEFAULT_URL_HOST`. 