### PR TITLE
Sort search results by newest studies first

### DIFF
--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -188,6 +188,7 @@ class Trial < ApplicationRecord
       indexes :max_age_unit, type: 'text'
       indexes :featured, type: 'integer'
       indexes :irb_number, type: 'text'
+      indexes :added_on, type: 'date'
     end
 
   end
@@ -221,7 +222,8 @@ class Trial < ApplicationRecord
         :cancer_yn,
         :min_age_unit,
         :max_age_unit,
-        :featured
+        :featured,
+        :added_on
       ],
       include: {
         trial_locations: {
@@ -284,7 +286,10 @@ class Trial < ApplicationRecord
       },
       highlight: {
         fields: highlight_fields
-      }
+      },
+      sort: [
+        { added_on: "desc" }
+      ]
     )
   end
 
@@ -316,7 +321,11 @@ class Trial < ApplicationRecord
       },
       highlight: {
         fields: highlight_fields
-      }
+      },
+      sort: [
+        { added_on: "desc" }
+      ]
+
     )
 
   end
@@ -329,7 +338,10 @@ class Trial < ApplicationRecord
           operator: "and",
           fields: ["display_title", "interventions", "conditions_map", "simple_description", "eligibility_criteria", "system_id", "keywords", "pi_name"]
         }
-      }
+      },
+      sort: [
+        { added_on: "desc" }
+      ]
     )
   end
 

--- a/db/migrate/20210402161847_add_added_on_to_trials.rb
+++ b/db/migrate/20210402161847_add_added_on_to_trials.rb
@@ -1,0 +1,5 @@
+class AddAddedOnToTrials < ActiveRecord::Migration[5.2]
+  def change
+    add_column :study_finder_trials, :added_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_02_004918) do
+ActiveRecord::Schema.define(version: 2021_04_02_161847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -249,6 +249,7 @@ ActiveRecord::Schema.define(version: 2021_03_02_004918) do
     t.string "contact_url_override"
     t.boolean "healthy_volunteers_imported"
     t.boolean "healthy_volunteers_override"
+    t.date "added_on"
   end
 
   create_table "study_finder_updaters", id: :serial, force: :cascade do |t|

--- a/lib/parsers/ctgov.rb
+++ b/lib/parsers/ctgov.rb
@@ -76,6 +76,12 @@ module Parsers
 
       retrieve_simple_fields(trial)
 
+      begin
+        trial.added_on = Date.parse(@contents.dig("study_first_posted")) || Date.today
+      rescue ArgumentError, TypeError => e
+        trial.added_on = Date.today
+      end
+
       if @contents.has_key?('eligibility')
         process_eligibility(trial)
       end

--- a/spec/models/trial_spec.rb
+++ b/spec/models/trial_spec.rb
@@ -17,4 +17,14 @@ describe Trial do
     expect(Trial.new(system_id: "NCT123").has_nct_number?).to be true
     expect(Trial.new(system_id: "nct123").has_nct_number?).to be true
   end
+
+  it "sorts search results by added_on date" do
+    Trial.create(added_on: 5.days.ago, visible: true)
+    Trial.create(added_on: 2.months.ago, visible: true)
+    Trial.create(added_on: 1.day.ago, visible: true)
+
+    result_dates = Trial.execute_search({q: ""}).results.map(&:added_on)
+
+    expect(result_dates).to eq(result_dates.sort.reverse)
+  end
 end


### PR DESCRIPTION
The search results previously had no explicit ordering. Because we're
using `match_all` queries we dont' get a relevancy score from
Elasticsearch.

This change introduces a new column on Trial: added_on. We can't use an
existing date (like created_at) because trials can be periodically
completely refreshed. Clinicaltrials.gov has a date that seems
appropriate for this use (date_first_posted) so we're defaulting to
that. This can of course be overridden with dates from other integrating
systems like OnCore.