### PR TITLE
Add trial API

### DIFF
--- a/app/controllers/api/studies_controller.rb
+++ b/app/controllers/api/studies_controller.rb
@@ -1,0 +1,39 @@
+class Api::StudiesController < ApiController
+  def index
+    render json: Trial.all
+  end
+
+  def show
+    @trial = Trial.find_by(system_id: params[:id])
+
+    render json: @trial
+  end
+
+  def update
+    @trial = Trial.find_by(system_id: params[:id])
+
+    if @trial.update(trial_params)
+      head 200
+    else
+      render json: { error: @trial.errors }, status: 400
+    end
+  end
+
+  private
+
+  def trial_params
+    params.permit(
+      :brief_title,
+      :contact_override,
+      :contact_override_first_name,
+      :contact_override_last_name,
+      :irb_number,
+      :overall_status,
+      :pi_id,
+      :pi_name,
+      :recruiting,
+      :simple_description,
+      :visible
+    )
+  end
+end

--- a/app/controllers/api/studies_controller.rb
+++ b/app/controllers/api/studies_controller.rb
@@ -33,6 +33,7 @@ class Api::StudiesController < ApiController
       :pi_name,
       :recruiting,
       :simple_description,
+      :brief_title,
       :visible
     )
   end

--- a/app/controllers/api/studies_controller.rb
+++ b/app/controllers/api/studies_controller.rb
@@ -1,18 +1,21 @@
 class Api::StudiesController < ApiController
   def index
-    render json: Trial.all
+    @trials = Trial.all
   end
 
   def show
     @trial = Trial.find_by(system_id: params[:id])
-
-    render json: @trial
   end
 
   def update
     @trial = Trial.find_by(system_id: params[:id])
 
-    if @trial.update(trial_params)
+    @trial.transaction do
+      @trial.update_keywords!(params[:keywords])
+      @trial.update!(trial_params)
+    end
+
+    if @trial.errors.none?
       head 200
     else
       render json: { error: @trial.errors }, status: 400

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,15 @@
+class ApiController < ActionController::API
+  before_action :restrict_to_authorized_tokens
+
+  private
+
+  def restrict_to_authorized_tokens
+    unless ApiKey.exists?(token: authorization_token)
+      head 401 and return
+    end
+  end
+
+  def authorization_token
+    request.headers["Authorization"].to_s.split(" ").last
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,7 @@
+class ApiKey < ApplicationRecord
+  validates :name, presence: true
+
+  after_initialize do |api_key|
+    api_key.token = SecureRandom.base58(32)
+  end
+end

--- a/app/models/trial.rb
+++ b/app/models/trial.rb
@@ -107,6 +107,25 @@ class Trial < ApplicationRecord
     trial_mesh_terms.map { |t| "#{t.mesh_term_type}: #{t.mesh_term}"}.join('; ') if trial_mesh_terms.any?
   end
 
+  def keyword_values
+    trial_keywords.map(&:keyword)
+  end
+
+  def update_keywords!(keywords)
+    return if keywords.nil?
+
+    existing_keywords = trial_keywords.map(&:keyword)
+    keywords_to_add = keywords - existing_keywords
+    keywords_to_delete = existing_keywords - keywords
+
+    transaction(requires_new: true) do
+      trial_keywords.where(keyword: keywords_to_delete).delete_all
+      keywords_to_add.each do |keyword|
+        trial_keywords.create(keyword: keyword)
+      end
+    end
+  end
+
   # ===============================================
   # Elasticsearch Configuration & Methods
   # ===============================================

--- a/app/views/api/studies/index.json.jbuilder
+++ b/app/views/api/studies/index.json.jbuilder
@@ -1,0 +1,16 @@
+json.array! @trials do |trial|
+  json.id trial.id
+  json.system_id trial.system_id
+  json.brief_title trial.brief_title
+  json.contact_override trial.contact_override
+  json.contact_override_first_name trial.contact_override_first_name
+  json.contact_override_last_name trial.contact_override_last_name
+  json.irb_number trial.irb_number
+  json.overall_status trial.overall_status
+  json.pi_id trial.pi_id
+  json.pi_name trial.pi_name
+  json.recruiting trial.recruiting
+  json.simple_description trial.simple_description
+  json.visible trial.visible
+  json.keywords trial.keywords
+end

--- a/app/views/api/studies/show.json.jbuilder
+++ b/app/views/api/studies/show.json.jbuilder
@@ -1,0 +1,14 @@
+json.id @trial.id
+json.system_id @trial.system_id
+json.brief_title @trial.brief_title
+json.contact_override @trial.contact_override
+json.contact_override_first_name @trial.contact_override_first_name
+json.contact_override_last_name @trial.contact_override_last_name
+json.irb_number @trial.irb_number
+json.overall_status @trial.overall_status
+json.pi_id @trial.pi_id
+json.pi_name @trial.pi_name
+json.recruiting @trial.recruiting
+json.simple_description @trial.simple_description
+json.visible @trial.visible
+json.keywords @trial.keyword_values

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,10 @@ Rails.application.routes.draw do
   get 'spotlight', controller: 'home', action: 'spotlight', as: :welcome
   get 'embed', controller: 'search', action: 'embed', as: :embed
 
+  namespace :api do
+    resources :studies, only: [:index, :show, :update]
+  end
+
   root 'home#index'
 
   # Example of regular route:

--- a/db/migrate/20210108230551_create_api_keys.rb
+++ b/db/migrate/20210108230551_create_api_keys.rb
@@ -1,0 +1,10 @@
+class CreateApiKeys < ActiveRecord::Migration[5.2]
+  def change
+    create_table :api_keys do |t|
+      t.string :name
+      t.string :token
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_02_161847) do
+ActiveRecord::Schema.define(version: 2021_01_08_230551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,13 @@ ActiveRecord::Schema.define(version: 2021_04_02_161847) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "api_keys", force: :cascade do |t|
+    t.string "name"
+    t.string "token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "showcase_items", force: :cascade do |t|

--- a/spec/controllers/api/studies_controller_spec.rb
+++ b/spec/controllers/api/studies_controller_spec.rb
@@ -17,7 +17,7 @@ describe Api::StudiesController do
     it "can read studies" do
       study = Trial.create!(system_id: "NCT123")
 
-      get :show, params: { id: study.system_id }
+      get :show, params: { id: study.system_id, format: :json }
 
       expect(response).to have_http_status(200)
     end

--- a/spec/controllers/api/studies_controller_spec.rb
+++ b/spec/controllers/api/studies_controller_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe Api::StudiesController do
+  context "unauthenticated requests" do
+    it "are rejected" do
+      get :show, params: { id: "NCT123" }
+      expect(response).to have_http_status(401)
+    end
+  end
+
+  context "authenticated requests" do
+    before do
+      api_key = ApiKey.create!(name: "blah")
+      request.headers["Authorization"] = "bearer #{api_key.token}"
+    end
+
+    it "can read studies" do
+      study = Trial.create!(system_id: "NCT123")
+
+      get :show, params: { id: study.system_id }
+
+      expect(response).to have_http_status(200)
+    end
+
+    it "can update studies" do
+      study = Trial.create!(system_id: "NCT345")
+      attributes_to_update = {
+        contact_override: "blah@example.com",
+        contact_override_first_name: "Testy",
+        contact_override_last_name: "McTesterson",
+        irb_number: "1234567890",
+        pi_id: "somepi@example.com",
+        pi_name: "Some PI, M.D.",
+        recruiting: true,
+        simple_description: "This is a short description",
+        brief_title: "This is a brief title",
+        visible: true
+      }
+
+      patch :update, params: attributes_to_update.merge(id: "NCT345")
+
+      expect(response).to have_http_status(200)
+
+      study.reload
+
+      attributes_to_update.each do |attribute, value|
+        expect(study[attribute]).to eq(value)
+      end
+    end
+  end
+end
+

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe ApiKey do
+  it "should generate a token when created" do
+    expect(subject.token.length).to eq(32)
+  end
+
+  it "should require a name" do
+    subject.save
+    expect(subject.errors).to have_key(:name)
+  end
+end

--- a/spec/models/trial_spec.rb
+++ b/spec/models/trial_spec.rb
@@ -1,6 +1,44 @@
 require "rails_helper"
 
 describe Trial do
+  it "updates keywords from an array of strings" do
+    trial = Trial.create
+    trial.update_keywords!(["one", "two"])
+    trial.reload
+
+    expect(trial.keyword_values).to include("one")
+    expect(trial.keyword_values).to include("two")
+    expect(trial.keyword_values.size).to eq(2)
+  end
+
+  it "deletes keywords from an array of strings" do
+    trial = Trial.create
+    trial.update_keywords!(["one", "two"])
+    trial.reload
+
+    expect(trial.keyword_values).to include("one")
+    expect(trial.keyword_values).to include("two")
+
+    trial.update_keywords!(["two"])
+    trial.reload
+
+    expect(trial.keyword_values).to eq(["two"])
+  end
+
+
+  it "ignores keyword updates with nil" do
+    trial = Trial.create
+    trial.update_keywords!(["one"])
+    trial.reload
+
+    expect(trial.keyword_values).to eq(["one"])
+
+    trial.update_keywords!(nil)
+    trial.reload
+
+    expect(trial.keyword_values).to eq(["one"])
+  end
+
   it "calculates healthy_volunteers" do
     trial = Trial.create(healthy_volunteers_imported: false)
     expect(trial.healthy_volunteers).to be false


### PR DESCRIPTION
This API was extracted from UMN's StudyFinder. It allows external processes to update basic Trial data and keywords from outside the application. It's meant to be used to augment the CT.gov data with data from other sources (like CTMS, IRB, etc).