### PR TITLE
Update database initialization instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Contact the StudyFinder team at studyfinder@umn.edu if you:
 
 The easiest way to get started with a development environment is to use `docker-compose`:
 
-1. Run `docker-compose run web rake db:create db:migrate db:seed` to initialize your
+1. Run `docker-compose run web rake db:setup` to initialize your
 database and search index.
 1. Run `docker-compose up -d` to start a development server.
 1. Visit `http://localhost:3000/` to view the application.


### PR DESCRIPTION
Now that that database views have been removed (in  #130) we can just
`rails db:setup` instead of manually doing a `db:create`, `db:migrate`,
and `db:seed`. The views were previously not present in `schema.rb`, which
`db:setup` uses.

This PR depends on #130.