### PR TITLE
Enable CI via GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare database
+      run: docker-compose run web rails db:setup
+    - name: Run tests
+      run: docker-compose run web rspec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# StudyFinder
-[![Build Status](https://travis-ci.org/ahcis-rds/study_finder.svg?branch=master)](https://travis-ci.org/ahcis-rds/study_finder)
+# StudyFinder [![Build Status](https://github.com/ahcis-rds/study_finder/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/ahcis-rds/study_finder/actions/workflows/ci.yml?query=branch%3Amaster)
 
 StudyFinder is a flexible and configurable application that pulls studies from
 clinicaltrials.gov and augments the data from alternate datasources such as a

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,8 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+Trial.__elasticsearch__.create_index!
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
This enables CI via Github Actions. It's configured to build any push from any branch right now, which I think is fine for the amount of activity this project sees.